### PR TITLE
Feature descriptor 4review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ test/image_results/
 test/tdb/
 documentation/html/
 documentation/latex/
+*.so
+*.os
+*.o

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,13 @@
-Currently the VCL works on Ubuntu Linux (v16.04) with OpenCV (v3.3) and TileDB (v1.2.2), but it should work on any recent version of Ubuntu. It's also been tested with g++ v5.4.0. If you're having issues, check your Ubuntu and g++ versions first. 
+Currently the VCL works on Ubuntu Linux (v16.04) with OpenCV (v3.3) and TileDB
+(v1.2.2), but it should work on any recent version of Ubuntu. It's also been
+tested with g++ v5.4.0. If you're having issues, check your Ubuntu and g++
+versions first.
 
 ## Basic Dependencies
     sudo apt-get install git wget
 
-If your system does not have [scons](http://scons.org/) installed, run the following:
+If your system does not have [scons](http://scons.org/) installed,
+run the following:
 
     sudo apt-get install scons
 
@@ -11,14 +15,15 @@ If your system does not have [scons](http://scons.org/) installed, run the follo
 
     sudo apt-get install cmake libgtest-dev
 
-Unfortunately this doesn't actually install gtest; you need to do the following steps to get it to work correctly:
+Unfortunately this doesn't actually install gtest;
+you need to do the following steps to get it to work correctly:
 
     cd /usr/src/gtest/
     sudo cmake CMakeLists.txt
     sudo make
     sudo cp *.a /usr/lib
 
-[Doxygen](http://www.stack.nl/~dimitri/doxygen/) is used to create the API documentation. To install: 
+[Doxygen](http://www.stack.nl/~dimitri/doxygen/) is used to create the API documentation. To install:
 
     sudo apt-get install doxygen
 
@@ -33,10 +38,14 @@ Download [OpenCV 3.3.1](https://github.com/opencv/opencv/archive/3.3.1.zip)
     cd build/
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
     make -jX   # substitute X for maximum number of CPUs (or leave it off to use all available)
-    sudo make install  
+    sudo make install
 
 ## [TileDB](https://tiledb.io/)
-Currently the VCL works with TileDB v1.2.2. It has not been tested with the Docker image, though please let us know if you try that and it works! The directions below will help you install TileDB v1.2.2 from source. You can also follow the directions listed [here](https://docs.tiledb.io/en/latest/installation.html).
+Currently the VCL works with TileDB v1.3.1. It has not been tested with the
+Docker image, though please let us know if you try that and it works! The
+directions below will help you install TileDB v1.3.1 from source. You can also
+follow the directions listed
+[here](https://docs.tiledb.io/en/latest/installation.html).
 
 ### Dependencies
     sudo apt-get install zlib1g-dev libssl-dev liblz4-dev libbz2-dev
@@ -58,19 +67,43 @@ Currently the VCL works with TileDB v1.2.2. It has not been tested with the Dock
     sudo make install PREFIX='/usr'
 
 ### Build TileDB
-    
+
     git clone https://github.com/TileDB-Inc/TileDB
     cd TileDB
-    git checkout 1.2.2
+    git checkout 1.3.1
     mkdir build
     cd build
     ../bootstrap --prefix=/usr/local/
     make -jX   # substitute X for maximum number of CPUs (or leave it off to use all available)
     sudo make install
-    
-**Note:** If you have previously installed TileDB v0.6.1 on your machine, 
-you will need to remove the existing header file (/usr/local/include/tiledb.h), 
+
+**Note:** If you have previously installed other version of TileDB
+on your machine, you will need to remove the existing header file
+(/usr/local/include/tiledb.h),
 since the newer version of TileDB installs to /usr/local/include/tiledb/.
+
+## [Faiss](https://github.com/facebookresearch/faiss)
+Facebook Faiss library for similarity search, used as alternitive engines
+on VCL::DescriptorSet.
+
+Download [Faiss 1.2.1](https://github.com/facebookresearch/faiss/archive/v1.2.1.tar.gz)
+
+    tar -xzvf v1.2.1.tar.gz
+    cd faiss-1.2.1
+    mkdir build
+    cd build/
+    cmake ..
+    make -j
+
+    # You may need to change some flags in the CMakeFile depending on
+    # configurations on your system
+
+    # This library does not offer an install
+    # make sure you move .h files to /usr/lib/include/faiss or
+    # /usr/local/lib/include/faiss
+    # make sure you make the library (libfaiss.so) is available
+    # system-wide
+    # Or follow instructions [here](https://github.com/facebookresearch/faiss/blob/v1.2.1/INSTALL.md)
 
 ## Compilation
     git clone https://github.com/IntelLabs/vcl # or download a release
@@ -81,6 +114,5 @@ Make sure libvcl is on your LD_LIBRARY_PATH
 
 To run the unit tests:
 
-    mkdir test/image_results
-    rm -r tdb/
-    ./test/unit_test
+    cd test
+    sh run_tests.sh

--- a/SConstruct
+++ b/SConstruct
@@ -1,30 +1,36 @@
 ## Compile and Build Library ##
 
-env = Environment(CPPPATH=['include', 'src'], CXXFLAGS="-std=c++11 -fopenmp -O3")
+env = Environment(CPPPATH=['include', 'src',
+                           '/usr/local/include/'],
+                  CXXFLAGS="-std=c++11 -O3 -fopenmp")
 
-source_files = ['src/Image.cc', 'src/ImageData.cc', 'src/TDBObject.cc',
-    'src/TDBImage.cc',
-    'src/Exception.cc',
-    'src/utils.cc'
-    ]
+source_files = [
+                'src/utils.cc',
+                'src/Exception.cc',
+                'src/TDBObject.cc',
+                'src/Image.cc',
+                'src/ImageData.cc',
+                'src/TDBImage.cc',
+                'src/DescriptorSet.cc',
+                'src/DescriptorSetData.cc',
+                'src/FaissDescriptorSet.cc',
+                'src/TDBDescriptorSet.cc',
+                'src/TDBDenseDescriptorSet.cc',
+                'src/TDBSparseDescriptorSet.cc',
+                ]
 
 env.SharedLibrary('libvcl.so', source_files,
-    LIBS = [ 'tiledb', 'opencv_core', 'opencv_imgproc', 'opencv_imgcodecs', 'gomp'],
-    LIBPATH = ['/usr/local/lib', '/usr/lib'])
+    LIBS = [ 'tiledb',
+             'opencv_core',
+             'opencv_imgproc',
+             'opencv_imgcodecs',
+             'gomp',
+             'faiss',
+             ],
 
-## Compile and Run Tests ##
+    LIBPATH = ['/usr/local/lib',
+               '/usr/lib',
+              ],
 
-gtest_source = ['test/unit_tests/main_test.cc'
-         , 'test/unit_tests/TDBImage_test.cc'
-         , 'test/unit_tests/ImageData_test.cc'
-         ,'test/unit_tests/Image_test.cc'
-]
-
-env.Program('test/unit_test', gtest_source,
-        LIBS = ['vcl', 'gtest', 'pthread'
-                ,'opencv_core'
-                , 'opencv_imgcodecs'
-                , 'opencv_highgui'
-                , 'opencv_imgproc'
-        ],
-        LIBPATH = ['.', '/usr/local/lib', '/usr/lib'])
+    LINKFLAGS="-Wl,--no-as-needed",
+    )

--- a/include/DescriptorSet.h
+++ b/include/DescriptorSet.h
@@ -1,0 +1,348 @@
+/**
+* @file   DescriptorSet.h
+*
+* @section LICENSE
+*
+* The MIT License
+*
+* @copyright Copyright (c) 2017 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"),
+* to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @section DESCRIPTION
+*
+* This file declares the C++ API for DescriptorSet.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "Exception.h"
+
+namespace VCL {
+
+    enum DescriptorSetEngine {FaissFlat, FaissIVFFlat,
+                              TileDBDense, TileDBSparse};
+
+    enum DistanceMetric {L2, IP};
+
+    class DescriptorSet {
+
+    public:
+
+        typedef std::vector<long>  DescIdVector;
+        typedef std::vector<long>  LabelIdVector;
+        typedef std::vector<float> DistanceVector;
+        typedef float* DescData;
+        typedef float* DescDataArray;
+
+        class DescriptorSetData;
+
+    private:
+
+        DescriptorSetData* _set;
+        DescriptorSetEngine _eng;
+
+        void write_set_info();
+        void read_set_info(const std::string& set_path);
+
+    public:
+        /**
+         *  Loads an existing collection located at set_path
+         *
+         *  @param set_path  Full Path to the collection folder
+         */
+        DescriptorSet(const std::string& set_path);
+
+        /**
+         *  Creates a new collection, if it does not exist
+         *
+         *  @param set_path  Full Path to the set folder
+         *  @param dim  Dimension of the descriptor
+         *  @param eng  DescriptorSet Engine (Default is FaissFlat)
+         *  @param metric Metric for calculating distances (Default is L2)
+         */
+        DescriptorSet(const std::string &set_path, unsigned dim,
+                      DescriptorSetEngine eng = FaissFlat,
+                      DistanceMetric metric = L2);
+
+        ~DescriptorSet();
+
+        // For now, we don't allow copy of objects.
+        // We will defined this behavoir later based on use-cases.
+        // Out use-cases now do not require copies, as the
+        // objects are besically used to access/operate the sets.
+        DescriptorSet(const DescriptorSetData&) = delete;
+
+        /**
+         *  Writes the DescriptorSet Index to the system. This will overwrite
+         *  the original
+         */
+        void store();
+
+        /**
+         *  Writes the DescriptorSet Index to the system into a defined path.
+         *  This will overwrite any other index under the same set_path.
+         */
+        void store(std::string set_path);
+
+        /*  *********************** */
+        /*      CORE INTERFACE      */
+        /*  *********************** */
+
+        /**
+         *  Returns the path to the root directory where all the
+         *  files are for the Set are stored
+         */
+        std::string get_path();
+
+        /**
+         *  Returns the number of dimensions of each descriptor in the set
+         */
+        unsigned get_dimensions();
+
+        /**
+         *  Returns the number of descriptors in the set
+         */
+        long get_n_descriptors();
+
+        /**
+         *  Inserts n descriptors and their labels into the set
+         *  Both descriptors and labels must have the same number of elements,
+         *  or labels can have no elements.
+         *  If not labels are defined, -1 is assigned to signify "no label".
+
+         *  Note: Given the in-memory nature of the Faiss library, adding
+         *  elements on a set using Faiss as engine will not persist the data
+         *  until the store() method is call. This is contrary to the TileDB
+         *  engines, where every add will return after persisting the data.
+
+         *  @param descriptors Buffer to descriptors (size n * dim)
+         *  @param n Number of descriptors
+         *  @param labels Array of labels, can be NULL.
+         */
+        long add(DescDataArray descriptors, unsigned n, long* labels = NULL);
+
+        /**
+         *  Search for the k closest neighborhs
+         *
+         *  @param query  Query descriptors buffer
+         *  @param n Number of descriptors that will be queried
+         *  @param k Number of maximun neighbors to be returned
+         *  @return ids  id of each neighbor (size n * k) (padded with -1)
+         *  @return distances  distances to each neighbor (size n * k).
+                               (padded with -1)
+         */
+        void search(DescDataArray queries, unsigned n, unsigned k,
+                    long* ids, float* distances);
+
+        /**
+         *  Search for neighborhs within a radius.
+         *
+         *  Note: We only allow the radius search of a single
+         *  element to avoid having to deal with results that are
+         *  of different (unknown) sized for each query.
+         *  We will work on it once we have a more clear use case for
+         *  this call
+         *
+         *  @param query  Query vector
+         *  @param radius  Maximun distance allowed
+         *  @param ids  Array of ID of the descriptors
+         *  @param distances  Distances of each neighbor
+         */
+        void radius_search(DescData query, float radius,
+                           long* ids, float* distances);
+
+        /**
+         *  Find the label of the feature vector, based on the closest
+         *  neighbors.
+         *
+         *  @param descriptors Buffer to descriptors (size n * dim)
+         *  @param n  Number of descriptors in buffer
+         *  @return labels  Label Ids
+         *  @param quorum  Number of elements used for the classification vote.
+         */
+        void classify(DescDataArray descriptors, unsigned n, long* labels,
+                      unsigned quorum = 7);
+
+        /**
+         *  Get the descriptors by specifiying ids.
+         *  This is an exact search by id.
+         *
+         *  @param ids  buffer with ids
+         *  @param n  number of ids to query
+         *  @return descriptors pointer to descriptors buffer
+                                size: (n * dim * sizeof(float))
+         */
+        void get_descriptors(long* ids, unsigned n, DescDataArray descriptors);
+
+        /**
+         *  Trains the index with the data present in the collection
+         *  using the specified metric
+         */
+        void train();
+
+        /**
+         *  Trains the index using specified descriptors
+         *
+         *  @param descriptors Reference Descriptors
+         *  @param n Number of descriptors
+         */
+        void train(DescDataArray descriptors, unsigned n);
+
+        /**
+         *  Returns true if the index is trained (train() method called),
+         *  false otherwhise.
+         */
+        bool is_trained();
+
+        /*  *********************** */
+        /*   VECTOR-BASED INTERFACE */
+        /*  *********************** */
+
+        // This are all wrapper around the core-interface
+        // That are usually useful.
+
+        /**
+         *  Inserts several Descriptors and their labels into the collection
+         *  Both Descriptors and labels must have the same length.
+         *
+         *  @param descriptors  Pointer to buffer containing the DescriptorSet
+         *  @param n  Number of elements per descriptor
+         *  @param labels  Vector of labels
+         *  @return id of the first (sequential ids)
+         */
+        long add(DescDataArray descriptors, unsigned n, LabelIdVector& labels);
+
+        /**
+         *  Search for the k closest neighborhs
+         *      // Add comment on why we use k and n_queries.
+         *      // We can also get rid of the
+         *
+         *  @param query  Query descriptors buffer
+         *  @param n_queries Number of descriptors that will be queried
+         *  @param k  Number of maximun neighbors to be returned
+         *  @return distances  distances of each neighbor (size n * k).
+         *  @return descriptors_ids  distances of each neighbor (size n * k).
+         */
+        void search(DescDataArray query, unsigned n, unsigned k,
+                    DescIdVector& ids, DistanceVector& distances);
+
+        /**
+         *  Find the label of the feature vector, based on the closest
+         *  neighbors.
+         *
+         *  @param query  Query descriptors buffer
+         *  @param n_queries Number of descriptors that will be classified
+         *  @param quorum  Number of elements used for the classification vote.
+         *  @return Vector with LabelIds.
+         */
+        LabelIdVector classify(DescDataArray descriptors, unsigned n,
+                               unsigned quorum = 7);
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids of size n
+         *  @param descriptors return pointer for the float values (n * d)
+         */
+        void get_descriptors(DescIdVector& ids, DescDataArray descriptors);
+
+        /*  *********************** */
+        /*   STRING-LABELS SUPPORT  */
+        /*  *********************** */
+
+        /**
+         *  Set the matching between label id and the string corresponding
+         *  to the label
+         *
+         *  @param ids  ids of the labels
+         *  @param labels  string for each label
+         */
+        void set_labels_map(std::map<long, std::string>& labels);
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids
+         *  @return vector with the string labels
+         */
+        std::map<long, std::string> get_labels_map();
+
+        /**
+         *  Set the matching between label id and the string corresponding
+         *  to the label
+         *
+         *  @param ids  vector of ids of the labels
+         *  @param labels  vector of string for each label
+         */
+        void set_labels_map(LabelIdVector& ids,
+                            std::vector<std::string>& labels);
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of descriptor's id
+         *  @return vector with the string labels
+         */
+        std::vector<std::string> get_str_labels(DescIdVector& ids);
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids
+         *  @return vector with the string labels
+         */
+        std::vector<std::string> label_id_to_string(LabelIdVector& l_id);
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids
+         *  @return vector with the string labels
+         */
+        std::vector<std::string> get_str_labels(long* ids, unsigned n);
+
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids
+         *  @return vector with the string labels
+         */
+        long get_label_id(const std::string& label);
+    };
+};

--- a/include/Exception.h
+++ b/include/Exception.h
@@ -39,6 +39,7 @@ namespace VCL {
 
       UnsupportedFormat,
       UnsupportedOperation,
+      UnsupportedIndex,
 
       ObjectNotFound,
       OpenFailed,

--- a/src/DescriptorSet.cc
+++ b/src/DescriptorSet.cc
@@ -1,0 +1,283 @@
+/**
+ * @file   DescriptorSet.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string>
+#include <iostream>
+
+#include "DescriptorSet.h"
+#include "DescriptorSetData.h"
+#include "FaissDescriptorSet.h"
+#include "TDBDescriptorSet.h"
+
+#define INFO_FILE_NAME "eng_info.txt"
+
+namespace VCL {
+
+DescriptorSet::DescriptorSet(const std::string &set_path)
+{
+    read_set_info(set_path);
+
+    if (_eng == DescriptorSetEngine(FaissFlat))
+        _set = new FaissFlatDescriptorSet(set_path);
+    else if (_eng == DescriptorSetEngine(FaissIVFFlat))
+        _set = new FaissIVFFlatDescriptorSet(set_path);
+    else if (_eng == DescriptorSetEngine(TileDBDense))
+        _set = new TDBDenseDescriptorSet(set_path);
+    else if (_eng == DescriptorSetEngine(TileDBSparse))
+        _set = new TDBSparseDescriptorSet(set_path);
+    else {
+        std::cerr << "Index Not supported" << std::endl;
+        throw VCLException(UnsupportedIndex, "Index not supported");
+    }
+}
+
+DescriptorSet::DescriptorSet(const std::string &set_path,
+                             unsigned dim,
+                             DescriptorSetEngine eng,
+                             DistanceMetric metric):
+    _eng(eng)
+{
+    if (eng == DescriptorSetEngine(FaissFlat))
+        _set = new FaissFlatDescriptorSet(set_path, dim, metric);
+    else if (eng == DescriptorSetEngine(FaissIVFFlat))
+        _set = new FaissIVFFlatDescriptorSet(set_path, dim, metric);
+    else if (eng == DescriptorSetEngine(TileDBDense))
+        _set = new TDBDenseDescriptorSet(set_path, dim, metric);
+    else if (eng == DescriptorSetEngine(TileDBSparse))
+        _set = new TDBSparseDescriptorSet(set_path, dim, metric);
+    else {
+        std::cerr << "Index Not supported" << std::endl;
+        throw VCLException(UnsupportedIndex, "Index not supported");
+    }
+}
+
+DescriptorSet::~DescriptorSet()
+{
+    delete _set;
+}
+
+void DescriptorSet::write_set_info()
+{
+    std::string path = _set->get_path() + "/" + INFO_FILE_NAME;
+    std::ofstream info_file(path);
+    info_file << _eng << std::endl;
+    info_file.close();
+}
+
+void DescriptorSet::read_set_info(const std::string& set_path)
+{
+    std::string path = set_path + "/" + INFO_FILE_NAME;
+    std::ifstream info_file(path);
+
+    if (!info_file.good()) {
+        std::cout << "cannot open: " << path << std::endl;
+        throw VCLException(OpenFailed, "Cannot open: " + path);
+    }
+
+    int num;
+    std::string str;
+    std::getline(info_file, str);
+    std::stringstream sstr(str);
+    sstr >> num;
+    _eng = (DescriptorSetEngine)num;
+    info_file.close();
+}
+
+    /*  *********************** */
+    /*      CORE INTERFACE      */
+    /*  *********************** */
+
+std::string DescriptorSet::get_path()
+{
+    return _set->get_path();
+}
+
+unsigned DescriptorSet::get_dimensions()
+{
+    return _set->get_dimensions();
+}
+
+long DescriptorSet::get_n_descriptors()
+{
+    return _set->get_n_total();
+}
+
+void DescriptorSet::search(DescDataArray queries, unsigned n_queries,
+                           unsigned k, long* descriptors_ids, float* distances)
+{
+    _set->search(queries, n_queries, k, descriptors_ids, distances);
+}
+
+void DescriptorSet::radius_search(DescData queries, float radius,
+                                  long* descriptors_ids, float* distances)
+{
+    _set->radius_search(queries, radius, descriptors_ids, distances);
+}
+
+long DescriptorSet::add(DescDataArray descriptors, unsigned n, long* labels)
+{
+    _set->add(descriptors, n, labels);
+}
+
+void DescriptorSet::train()
+{
+    _set->train();
+}
+
+void DescriptorSet::train(DescDataArray descriptors, unsigned n)
+{
+    _set->train(descriptors, n);
+}
+
+bool DescriptorSet::is_trained()
+{
+    _set->is_trained();
+}
+
+void DescriptorSet::classify(DescDataArray descriptors, unsigned n,
+                            long* labels, unsigned quorum)
+{
+    _set->classify(descriptors, n, labels, quorum);
+}
+
+void DescriptorSet::get_descriptors(long* ids, unsigned n, DescDataArray descriptors)
+{
+    _set->get_descriptors(ids, n, descriptors);
+}
+
+void DescriptorSet::store()
+{
+    _set->store();
+    write_set_info();
+}
+
+void DescriptorSet::store(std::string set_path)
+{
+    _set->store(set_path);
+    write_set_info();
+}
+
+    /*  *********************** */
+    /*   VECTOR-BASED INTERFACE */
+    /*  *********************** */
+
+long DescriptorSet::add(DescDataArray descriptors, unsigned n,
+                        LabelIdVector& labels)
+{
+    if (n != labels.size() && labels.size() != 0)
+        throw VCLException(SizeMismatch, "Labels Vector of Wrong Size");
+
+    add(descriptors, n, labels.size() > 0 ? (long*) labels.data() : NULL);
+}
+
+void DescriptorSet::search(DescDataArray queries, unsigned n, unsigned k,
+                           DescIdVector& ids, DistanceVector& distances)
+{
+    ids.resize(n * k);
+    distances.resize(n * k);
+    search(queries, n, k, ids.data(), distances.data());
+}
+
+std::vector<long> DescriptorSet::classify(DescDataArray descriptors, unsigned n,
+                                          unsigned quorum)
+{
+    LabelIdVector labels;
+    labels.resize(n);
+    classify(descriptors, n, labels.data(), quorum);
+    return labels;
+}
+
+void DescriptorSet::get_descriptors(std::vector<long>& ids, float* descriptors)
+{
+    get_descriptors(ids.data(), ids.size(), descriptors);
+}
+
+    /*  *********************** */
+    /*   STRING-LABELS SUPPORT  */
+    /*  *********************** */
+
+void DescriptorSet::set_labels_map(std::map<long, std::string>& labels)
+{
+    return _set->set_labels_map(labels);
+}
+
+std::map<long, std::string> DescriptorSet::get_labels_map()
+{
+    return _set->get_labels_map();
+}
+
+void DescriptorSet::set_labels_map(LabelIdVector& ids,
+                                   std::vector<std::string>& labels)
+{
+    assert (ids.size() == labels.size());
+    std::map<long, std::string> labels_map;
+    for (int i = 0; i < ids.size(); ++i) {
+        labels_map[ids[i]] = labels[i];
+    }
+
+    set_labels_map(labels_map);
+}
+
+std::vector<std::string> DescriptorSet::label_id_to_string(LabelIdVector& l_id)
+{
+    std::vector<std::string> ret_labels(l_id.size());
+    std::map<long, std::string> labels_map = _set->get_labels_map();
+
+    for (int i = 0; i < l_id.size(); ++i) {
+        ret_labels[i] = labels_map[l_id[i]];
+    }
+    return ret_labels;
+}
+
+long DescriptorSet::get_label_id(const std::string& label)
+{
+    auto map = _set->get_labels_map();
+
+    for (auto it = map.begin(); it != map.end(); ++it ) {
+        if (it->second == label) {
+            return it->first;
+        }
+    }
+
+    long id = map.size();
+    map[id] = label;
+    _set->set_labels_map(map);
+
+    return id;
+}
+
+std::vector<std::string> DescriptorSet::get_str_labels(DescIdVector& ids)
+{
+    return _set->get_str_labels(ids.data(), ids.size());
+}
+
+}

--- a/src/DescriptorSetData.cc
+++ b/src/DescriptorSetData.cc
@@ -1,0 +1,127 @@
+/**
+*
+* @section LICENSE
+*
+* The MIT License
+*
+* @copyright Copyright (c) 2017 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"),
+* to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @section DESCRIPTION
+*
+*/
+
+#include <assert.h>
+#include <sstream>
+
+#include "DescriptorSetData.h"
+#include "Exception.h"
+
+using namespace VCL;
+
+DescriptorSet::DescriptorSetData::DescriptorSetData(const std::string &set_path):
+    _set_path(set_path)
+{
+    if (!dir_exist(set_path)) {
+        throw VCLException(OpenFailed, "File does not exists");
+    }
+}
+
+DescriptorSet::DescriptorSetData::DescriptorSetData(
+                                            const std::string &set_path,
+                                            uint32_t dim) :
+    _set_path(set_path),
+    _dimensions(dim),
+    _n_total(0)
+{
+    if (dir_exist(set_path)) {
+        throw VCLException(OpenFailed, "File already exists");
+    }
+}
+
+DescriptorSet::DescriptorSetData::~DescriptorSetData()
+{
+}
+
+void DescriptorSet::DescriptorSetData::radius_search(
+                                    float* query, float radius,
+                                    long* descriptors, float* distances)
+{
+    throw VCLException(UnsupportedOperation, "Not Implemented");
+}
+
+// String labels handling
+
+void DescriptorSet::DescriptorSetData::set_labels_map(std::map<long,std::string>& labels)
+{
+    _labels_map_lock.lock();
+    _labels_map = labels;
+    _labels_map_lock.unlock();
+}
+
+std::vector<std::string> DescriptorSet::DescriptorSetData::get_str_labels(
+                    long* ids, unsigned n)
+{
+    std::vector<std::string> str_labels(n);
+    std::vector<long> labels(n);
+
+    get_labels(ids, n, labels.data());
+
+    _labels_map_lock.lock();
+    for (int i = 0; i < n; ++i) {
+        assert(labels[i] < _labels_map.size());
+        str_labels[i] = _labels_map[labels[i]];
+    }
+    _labels_map_lock.unlock();
+
+    return str_labels;
+}
+
+void DescriptorSet::DescriptorSetData::write_labels_map()
+{
+    std::ofstream out_labels(_set_path + "/labels.txt");
+
+    _labels_map_lock.lock();
+    for (auto& label : _labels_map) {
+        out_labels << label.first << " " << label.second << std::endl;
+    }
+    _labels_map_lock.unlock();
+
+    out_labels.close();
+}
+
+void DescriptorSet::DescriptorSetData::read_labels_map()
+{
+    std::ifstream in_labels(_set_path + "/labels.txt");
+    std::string str;
+    _labels_map_lock.lock();
+    _labels_map.clear();
+    while (std::getline(in_labels, str)) {
+        std::stringstream sstr(str);
+        long id;
+        sstr >> id;
+        sstr >> str;
+        _labels_map[id] = str;
+    }
+    _labels_map_lock.unlock();
+    in_labels.close();
+}

--- a/src/DescriptorSetData.h
+++ b/src/DescriptorSetData.h
@@ -1,0 +1,267 @@
+/**
+*
+* @section LICENSE
+*
+* The MIT License
+*
+* @copyright Copyright (c) 2017 Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"),
+* to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @section DESCRIPTION
+*
+* This file declares the C++ Interface for the abstract DescriptorSetData object.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <mutex>
+#include <map>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
+
+#include "DescriptorSet.h"
+
+namespace VCL {
+
+    class DescriptorSet::DescriptorSetData {
+
+    protected:
+
+        std::string _set_path;
+        unsigned _dimensions;
+        uint64_t _n_total;
+
+        DistanceMetric _metric;
+
+        // String labels handling
+        std::mutex _labels_map_lock;
+        std::map<long, std::string> _labels_map;
+
+        inline bool file_exist(const std::string& name) {
+            std::ifstream f(name.c_str());
+            if (f.good()) {
+                f.close();
+                return true;
+            }
+            return false;
+        }
+
+        inline bool dir_exist(const std::string& dir_name) {
+            DIR* dir = opendir(dir_name.c_str());
+            if (dir)
+                return true;
+
+            return false;
+        }
+
+        inline int create_dir(const char *path){
+            struct stat sb;
+            while (1)
+                if (stat(path, &sb) == 0)
+                    if (sb.st_mode & S_IFDIR)
+                        return 0;
+                    else
+                        return EEXIST;
+                else if (errno != ENOENT)
+                    return errno;
+                else if (mkdir(path, 0777) == 0)
+                    return 0;
+                else if (errno != EEXIST)
+                    return errno;
+        }
+
+        void write_labels_map();
+        void read_labels_map();
+
+    public:
+        /**
+         *  Loads an existing collection located at collection_path
+         *  or created a new collection if it does not exist
+         *  Returns error if the set does not exist
+         *
+         *  @param filename  Full Path to the collection folder
+         */
+        DescriptorSetData(const std::string &filename);
+
+        /**
+         *  Creates collection located at filename
+         *  or created a new collection if it does not exist
+         *
+         *  @param filename  Full Path to the collection folder
+         *  @param dim  Dimension of the descriptor
+         */
+        DescriptorSetData(const std::string &filename, unsigned dim);
+
+        ~DescriptorSetData();
+
+        DescriptorSetData(const DescriptorSetData&) = delete;
+
+        std::string get_path()    { return _set_path; }
+
+        unsigned get_dimensions() { return _dimensions; }
+
+        /**
+         *  Returns the number of descriptors in the set
+         */
+        long get_n_total()        { return _n_total; }
+
+        /**
+         *  Inserts n descriptors and their labels into the set
+         *  Both descriptors and labels must have the same number of elements,
+         *  or labels can have no elements.
+         *  If not labels are defined, -1 is assigned to signify "no label".
+
+         *  Note: Given the in-memory nature of the Faiss library, adding
+         *  elements on a set using Faiss as engine will not persist the data
+         *  until the store() method is call. This is contrary to the TileDB
+         *  engines, where every add will return after persisting the data.
+
+         *  @param descriptors Buffer to descriptors (size n * dim)
+         *  @param n Number of descriptors
+         *  @param labels Array of labels, can be NULL.
+         */
+        virtual long add(float* descriptors, unsigned n_descriptors,
+                         long* labels = NULL) = 0;
+
+        /**
+         *  Search for the k closest neighborhs
+         *
+         *  @param query  Query descriptors buffer
+         *  @param n Number of descriptors that will be queried
+         *  @param k Number of maximun neighbors to be returned
+         *  @return ids  id of each neighbor (size n * k) (padded with -1)
+         *  @return distances  distances to each neighbor (size n * k).
+                               (padded with -1)
+         */
+        virtual void search(float* query, unsigned n, unsigned k,
+                            long* descriptors, float* distances) = 0;
+
+        /**
+         *  Search for neighborhs within a radius.
+         *
+         *  Note: We only allow the radius search of a single
+         *  element to avoid having to deal with results that are
+         *  of different (unknown) sized for each query.
+         *  We will work on it once we have a more clear use case for
+         *  this call
+         *
+         *  @param query  Query vector
+         *  @param radius  Maximun distance allowed
+         *  @param ids  Array of ID of the descriptors
+         *  @param distances  Distances of each neighbor
+         */
+        virtual void radius_search(float* query, float radius,
+                                   long* descriptors, float* distances);
+
+        /**
+         *  Find the label of the feature vector, based on the closest
+         *  neighbors.
+         *
+         *  @param descriptors Buffer to descriptors (size n * dim)
+         *  @param n  Number of descriptors in buffer
+         *  @return labels  Label Ids
+         *  @param quorum  Number of elements used for the classification vote.
+         */
+        virtual void classify(float* descriptors, unsigned n, long* ids,
+                              unsigned quorum) = 0;
+
+        /**
+         *  Get the descriptors by specifiying ids.
+         *  This is an exact search by id.
+         *
+         *  @param ids  buffer with ids
+         *  @param n  number of ids to query
+         *  @return descriptors pointer to descriptors buffer
+                                size: (n * dim * sizeof(float))
+         */
+        virtual void get_descriptors(long* ids, unsigned n,
+                                     float* descriptors) = 0;
+
+        virtual void get_labels(long* ids, unsigned n, long* labels) = 0;
+
+        /**
+         *  Trains the index with the data present in the collection
+         *  using the specified metric
+         */
+        virtual void train() {}
+
+        /**
+         *  Trains the index using specified descriptors
+         *
+         *  @param descriptors Reference Descriptors
+         *  @param n Number of descriptors
+         */
+        virtual void train(float* descriptors, unsigned n) { train(); }
+
+        virtual bool is_trained() {return false;}
+
+        /**
+         *  Writes the DescriptorSet Index to the system. This will overwrite
+         *  the original
+         */
+        virtual void store() = 0;
+
+        /**
+         *  Writes the DescriptorSet Index to the system into a defined path.
+         *  This will overwrite any other index under the same set_path.
+         */
+        virtual void store(std::string collection_path) = 0;
+
+        // String labels handling
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids
+         *  @return vector with the string labels
+         */
+        std::vector<std::string> get_str_labels(long* ids, unsigned n);
+
+        /**
+         *  Get the label of the descriptors for the spcified ids.
+         *  NOTE: This is a vector becase this is what we return.
+         *  We can, make wrapper functions that recieve arrays as well.
+         *
+         *  @param ids  vector of ids
+         *  @return vector with the string labels
+         */
+        std::map<long, std::string> get_labels_map() { return _labels_map; }
+
+        /**
+         *  Set the matching between label id and the string corresponding
+         *  to the label
+         *
+         *  @param ids  ids of the labels
+         *  @param labels  string for each label
+         */
+        void set_labels_map(std::map<long,std::string>& labels);
+    };
+
+};

--- a/src/FaissDescriptorSet.cc
+++ b/src/FaissDescriptorSet.cc
@@ -1,0 +1,377 @@
+/**
+ * @file   FaissDescriptorSet.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+#include <sys/types.h>
+#include <dirent.h>
+
+#include "FaissDescriptorSet.h"
+#include "Exception.h"
+
+#include <faiss/index_io.h>
+#include <faiss/FaissException.h>
+#include "faiss/AuxIndexStructures.h"
+
+#define FAISS_IDX_FILE_NAME "faiss.idx"
+#define IDS_IDX_FILE_NAME   "ids.arr"
+
+using namespace VCL;
+
+FaissDescriptorSet::FaissDescriptorSet(const std::string &set_path):
+    DescriptorSetData(set_path)
+{
+    _faiss_file = _set_path + "/" + FAISS_IDX_FILE_NAME;
+    read_label_ids();
+    read_labels_map();
+}
+
+FaissDescriptorSet::FaissDescriptorSet(const std::string &set_path,
+                                       unsigned dim) :
+    DescriptorSetData(set_path, dim)
+{
+    _faiss_file = _set_path + "/" + FAISS_IDX_FILE_NAME;
+}
+
+FaissDescriptorSet::~FaissDescriptorSet()
+{
+}
+
+void FaissDescriptorSet::write_label_ids()
+{
+    std::ofstream out_ids(_set_path + "/" + IDS_IDX_FILE_NAME,
+                          std::ofstream::binary);
+
+    unsigned ids_size = _label_ids.size();
+    out_ids.write((char*)&ids_size, sizeof(ids_size));
+    out_ids.write((char*)_label_ids.data(), sizeof(long) * ids_size);
+    out_ids.close();
+}
+
+void FaissDescriptorSet::read_label_ids()
+{
+    std::ifstream in_ids(_set_path + "/" + IDS_IDX_FILE_NAME,
+                         std::ofstream::binary);
+
+    if (!in_ids.good()) {
+        throw VCLException(OpenFailed, "Cannot read labels file");
+    }
+
+    unsigned ids_size;
+    in_ids.read((char*)&ids_size, sizeof(ids_size));
+    _label_ids.resize(ids_size);
+    in_ids.read((char*)_label_ids.data(), sizeof(long) * ids_size);
+    in_ids.close();
+}
+
+long FaissDescriptorSet::add(float* descriptors, unsigned n, long* labels)
+{
+    assert(n > 0);
+
+    _lock.lock();
+
+    long id_first = _index->ntotal;
+
+    if (labels != NULL) {
+        _label_ids.resize(_index->ntotal + n);
+        long* dst = _label_ids.data() + _index->ntotal;
+        std::memcpy(dst, labels, n * sizeof(long));
+    }
+
+    _index->add(n, descriptors);
+    _n_total = _index->ntotal;
+    _lock.unlock();
+
+    return id_first;
+}
+
+
+
+void FaissDescriptorSet::train()
+{
+    train_core(NULL,0);
+}
+
+void FaissDescriptorSet::train(float* descriptors, unsigned n)
+{
+    train_core(descriptors,n);
+}
+
+void FaissDescriptorSet::train_core(float* descriptors, unsigned n)
+{
+    _lock.lock();
+    long n_total = _index->ntotal;
+    float* recons = new float[n_total * _dimensions];
+    _index->reconstruct_n (0, n_total, recons);
+    _index->reset();
+    _index->train(n == 0? n_total : n, n == 0? recons : descriptors);
+    _index->add(n_total, recons);
+    _lock.unlock();
+
+    delete[] recons;
+}
+
+bool FaissDescriptorSet::is_trained()
+{
+    return _index->is_trained;
+}
+
+// No need to use locks on this read-only operation as faiss handles internally
+void FaissDescriptorSet::search(float* query, unsigned n_queries, unsigned k,
+                              long* descriptors, float* distances)
+{
+    _index->search(n_queries, query, k, distances, descriptors);
+}
+
+void FaissDescriptorSet::radius_search(float* query, float radius,
+                              long* descriptors, float* distances)
+{
+    faiss::RangeSearchResult rs(1); // 1 is the Number of queries
+    _index->range_search(1, query, radius, &rs);
+
+    // rs.lims is of size 2, as nq is of size 1.
+    // Check faiss::RangeSearchResult definition for more details.
+    long found = rs.lims[1];
+    std::memcpy(descriptors, rs.labels, sizeof(long)*found);
+    std::memcpy(distances, rs.distances, sizeof(float)*found);
+}
+
+void FaissDescriptorSet::classify(float* descriptors, unsigned n, long* ids,
+                                  unsigned quorum)
+{
+    float* distances = new float[n * quorum];
+    long*  ids_aux   = new long [n * quorum];
+
+    search(descriptors, n, quorum, ids_aux, distances);
+
+    _lock.lock();
+    for (int j = 0; j < n; ++j) {
+        std::map<long, int> map_voting;
+        long winner = -1;
+        unsigned max = 0;
+        for (int i = 0; i < quorum; ++i) {
+            long idx = ids_aux[quorum*j + i];
+            if (idx < 0)
+                continue; // Means not found
+
+            long label_id = _label_ids.at(idx);
+            map_voting[label_id] += 1;
+            if (max < map_voting[label_id]) {
+                max = map_voting[label_id];
+                winner = label_id;
+            }
+        }
+        ids[j] = winner;
+    }
+    _lock.unlock();
+}
+
+void FaissDescriptorSet::get_labels(long* ids, unsigned n, long* labels)
+{
+    _lock.lock();
+
+    for (int i = 0; i < n; ++i) {
+        long idx = ids[i];
+        if (idx > _label_ids.size()){
+            throw VCLException(ObjectNotFound, "Label id does not exists");
+        }
+        labels[i] = _label_ids[idx];
+    }
+
+    _lock.unlock();
+}
+
+void FaissDescriptorSet::get_descriptors(long* ids, unsigned n,
+                                         float* descriptors)
+{
+    int offset = 0;
+
+    try {
+        for (int i = 0; i < n; ++i) {
+            _index->reconstruct(ids[i], descriptors + i*_dimensions);
+        }
+    } catch(faiss::FaissException& e) {
+        throw VCLException(UndefinedException, "faiss::reconstruct(3) failed");
+    }
+}
+
+void FaissDescriptorSet::store()
+{
+    store(_set_path);
+}
+
+void FaissDescriptorSet::store(std::string set_path)
+{
+    _lock.lock();
+    _set_path = set_path;
+    _faiss_file = _set_path + "/" + FAISS_IDX_FILE_NAME;
+
+    int ret = create_dir(_set_path.c_str());
+    if (ret == 0 || ret == EEXIST) { // Directory exists or created
+        faiss::write_index((const faiss::IndexFlat*)(_index),
+                            _faiss_file.c_str());
+        write_label_ids();
+        _lock.unlock();
+
+        write_labels_map();
+    }
+    else {
+        throw VCLException(OpenFailed, _faiss_file +
+                "cannot be created or written. " +
+                "Error: " + std::to_string(ret));
+    }
+
+}
+
+// FaissFlatDescriptorSet
+
+FaissFlatDescriptorSet::FaissFlatDescriptorSet(const std::string &set_path):
+    FaissDescriptorSet(set_path)
+{
+    try {
+        _index = faiss::read_index(_faiss_file.c_str());
+
+    } catch(faiss::FaissException& e) {
+        throw VCLException(OpenFailed, "Problem reading: " + _faiss_file);
+    }
+
+    // Faiss will sometimes throw, or sometimes set _index = NULL,
+    // we check both just in case.
+    if (!_index) {
+        throw VCLException(OpenFailed, "Problem reading: " + _faiss_file);
+    }
+
+    _dimensions = _index->d;
+    _n_total = _index->ntotal;
+}
+
+FaissFlatDescriptorSet::FaissFlatDescriptorSet(const std::string &set_path,
+    unsigned dim, DistanceMetric metric)
+    : FaissDescriptorSet(set_path, dim)
+{
+    if (metric == L2)
+        _index = new faiss::IndexFlatL2(_dimensions);
+    else if (metric == IP)
+        _index = new faiss::IndexFlatIP(_dimensions);
+    else
+        throw VCLException(UnsupportedIndex, "Metric Not implemented");
+}
+
+// FaissIVFFlatDescriptorSet
+
+FaissIVFFlatDescriptorSet::FaissIVFFlatDescriptorSet(const std::string &set_path):
+    FaissDescriptorSet(set_path)
+{
+    try {
+        _index = (faiss::IndexIVFFlat*)faiss::read_index(_faiss_file.c_str());
+
+    } catch(faiss::FaissException& e) {
+        throw VCLException(OpenFailed, "Problem reading: " + _faiss_file);
+    }
+
+    // Faiss will sometimes throw, or sometimes set _index = NULL,
+    // we check both just in case.
+    if (!_index) {
+        throw VCLException(OpenFailed, "Problem reading: " + _faiss_file);
+    }
+
+    _dimensions = _index->d;
+    _n_total    = _index->ntotal;
+}
+
+FaissIVFFlatDescriptorSet::FaissIVFFlatDescriptorSet(
+            const std::string &set_path,
+            unsigned dim, DistanceMetric metric)
+    : FaissDescriptorSet(set_path, dim)
+{
+    // TODO: Revise nlist param for future optimizations.
+    // 4 is a suggested value by faiss for the IVFFlat index,
+    // that's why we leave it for now.
+    int nlist = 4;
+
+    if (metric == L2) {
+        faiss::IndexFlatL2* quantizer =
+            new faiss::IndexFlatL2(_dimensions);
+
+        _index = new faiss::IndexIVFFlat(quantizer, _dimensions,
+                                         nlist,
+                                         faiss::METRIC_L2);
+    }
+    else if (metric == IP) {
+        faiss::IndexFlatIP* quantizer =
+            new faiss::IndexFlatIP(_dimensions);
+
+        _index = new faiss::IndexIVFFlat(quantizer, _dimensions,
+                                         nlist,
+                                         faiss::METRIC_INNER_PRODUCT);
+    }
+    else
+        throw VCLException(UnsupportedIndex, "Metric Not implemented");
+}
+
+long FaissIVFFlatDescriptorSet::add(float* descriptors,
+                                    unsigned n, long* labels)
+{
+    assert(n > 0);
+
+    _lock.lock();
+
+    // This index need training before inserting elements.
+    // This will only happen the first time something is added,
+    // and will attempt to use the inserted elements for training.
+    if (!_index->is_trained) {
+
+        long desc_4_training = _dimensions * 100;
+
+        if (n < desc_4_training) {
+            // Train with random data
+            // The user can later call train() with better data.
+            std::vector<float> aux_desc(desc_4_training * _dimensions);
+            std::memcpy(aux_desc.data(), descriptors,
+                        n * _dimensions * sizeof(float));
+            _index->train(desc_4_training, aux_desc.data());
+        }
+        else {
+            _index->train(n, descriptors);
+        }
+
+        // This is needed for doing reconstructions:
+        // More info: https://github.com/facebookresearch/faiss/issues/374
+        ((faiss::IndexIVFFlat*)_index)->make_direct_map();
+    }
+    _lock.unlock();
+
+    long id_first = FaissDescriptorSet::add(descriptors, n, labels);
+
+    return id_first;
+}

--- a/src/FaissDescriptorSet.h
+++ b/src/FaissDescriptorSet.h
@@ -1,0 +1,120 @@
+/**
+ * @file   DescriptorSet.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the C++ API for DescriptorSet.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <mutex>
+
+#include "DescriptorSetData.h"
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFFlat.h>
+
+namespace VCL {
+
+    class FaissDescriptorSet : public DescriptorSet::DescriptorSetData {
+
+    protected:
+
+        std::string _faiss_file;
+
+        faiss::Index* _index;
+
+        std::mutex _lock;
+        std::vector<long> _label_ids;
+
+        void write_label_ids();
+        void read_label_ids();
+
+        void train_core(float* descriptors, unsigned n);
+
+    public:
+
+        FaissDescriptorSet(const std::string &set_path);
+        FaissDescriptorSet(const std::string &set_path, unsigned dim);
+
+        ~FaissDescriptorSet();
+
+        virtual long add(float* descriptors, unsigned n_descriptors,
+                         long* classes);
+
+        void train();
+
+        void train(float* descriptors, unsigned n);
+
+        bool is_trained();
+
+        void search(float* query, unsigned n, unsigned k,
+                    long* ids, float* distances);
+
+        void radius_search(float* query, float radius,
+                           long* ids, float* distances);
+
+        void classify(float* descriptors, unsigned n, long* ids,
+                      unsigned quorum);
+
+        void get_descriptors(long* ids, unsigned n, float* descriptors);
+
+        void get_labels(long* ids, unsigned n, long* labels);
+
+        void store();
+        void store(std::string set_path);
+
+    };
+
+    class FaissFlatDescriptorSet : public FaissDescriptorSet {
+
+    public:
+
+        FaissFlatDescriptorSet(const std::string& set_path);
+        FaissFlatDescriptorSet(const std::string& set_path, unsigned dim,
+                                 DistanceMetric metric);
+    };
+
+    class FaissIVFFlatDescriptorSet : public FaissDescriptorSet {
+
+    public:
+
+        FaissIVFFlatDescriptorSet(const std::string& set_path);
+        FaissIVFFlatDescriptorSet(const std::string& set_path, unsigned dim,
+                                    DistanceMetric metric);
+
+        long add(float* descriptors, unsigned n_descriptors, long* classes);
+    };
+};

--- a/src/TDBDenseDescriptorSet.cc
+++ b/src/TDBDenseDescriptorSet.cc
@@ -1,0 +1,253 @@
+/**
+ * @file   TDBDenseDescriptorSet.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstring>
+
+#include "TDBDescriptorSet.h"
+
+#include <tiledb/map.h>
+
+#define ATTRIBUTE_DESC  "descriptor"
+#define ATTRIBUTE_LABEL "label"
+
+using namespace VCL;
+
+TDBDenseDescriptorSet::TDBDenseDescriptorSet(const std::string &filename):
+    TDBDescriptorSet(filename),
+    _flag_buffer_updated(false)
+{
+    read_metadata();
+}
+
+TDBDenseDescriptorSet::TDBDenseDescriptorSet(const std::string &filename,
+                                     uint32_t dim,
+                                     DistanceMetric metric):
+    TDBDescriptorSet(filename, dim),
+    _flag_buffer_updated(true)
+{
+    auto d = tiledb::Dimension::create<uint64_t>(
+                            _tiledb_ctx, "d", {{0, MAX_DESC-1}}, 10);
+
+    tiledb::Domain domain(_tiledb_ctx);
+    domain.add_dimension(d);
+
+    tiledb::Attribute a_desc = tiledb::Attribute::create<float>(
+                                _tiledb_ctx, ATTRIBUTE_DESC);
+    a_desc.set_compressor({TILEDB_BLOSC_LZ, -1});
+    a_desc.set_cell_val_num(_dimensions);
+
+    tiledb::Attribute a_label = tiledb::Attribute::create<long>(
+                _tiledb_ctx, ATTRIBUTE_LABEL);
+    a_label.set_compressor({TILEDB_BLOSC_LZ, -1});
+
+    tiledb::ArraySchema schema(_tiledb_ctx, TILEDB_DENSE);
+    schema.set_tile_order(TILEDB_ROW_MAJOR).set_cell_order(TILEDB_ROW_MAJOR);
+    schema.set_domain(domain);
+    schema.add_attribute(a_desc);
+    schema.add_attribute(a_label);
+
+    try {
+        schema.check();
+    } catch (tiledb::TileDBError &e) {
+        throw VCLException(TileDBError, "Error creating TDB schema");
+    }
+
+    // Create array
+    tiledb::Array::create(_set_path, schema);
+
+    write_metadata();
+}
+
+void TDBDenseDescriptorSet::read_metadata()
+{
+    std::vector<long> metadata(2);
+
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_READ);
+    tiledb::Query query(_tiledb_ctx, array);
+    query.set_layout(TILEDB_ROW_MAJOR);
+    query.set_subarray<uint64_t>( {METADATA_OFFSET, METADATA_OFFSET+1} );
+    query.set_buffer(ATTRIBUTE_LABEL, metadata);
+    query.submit();
+
+    _dimensions = (unsigned)metadata[0];
+    _n_total    = (uint64_t)metadata[1];
+
+}
+
+void TDBDenseDescriptorSet::write_metadata()
+{
+    // Writing metadata using KV store in TileDB
+    // (thru the write_metadata(3) in TDBObject)
+    // is an overkill.
+    // We simply need to store 3-64bits values as
+    // metadata, which can be inserted in the
+    // 2-D array that we are already using.
+    // The following code does that, and the corresponding
+    // read_metadata() knows how to read these values back.
+
+    std::vector<long> metadata;
+    metadata.push_back(_dimensions);
+    metadata.push_back(_n_total);
+
+    // This is only here because tiledb requires all the
+    // attributes when writing.
+    std::vector<float> aux_dims(_dimensions * 2, .0f);
+
+    // Write metadata
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_WRITE);
+    tiledb::Query query(_tiledb_ctx, array);
+    query.set_layout(TILEDB_ROW_MAJOR);
+    query.set_subarray<uint64_t>({METADATA_OFFSET, METADATA_OFFSET+1});
+    query.set_buffer(ATTRIBUTE_LABEL, metadata);
+    query.set_buffer(ATTRIBUTE_DESC, aux_dims);
+    query.submit();
+    query.finalize();
+
+}
+
+void TDBDenseDescriptorSet::load_buffer()
+{
+    try {
+
+        read_metadata();
+
+        tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_READ);
+        {
+            _buffer.resize(_dimensions * _n_total);
+            _label_ids.resize(_n_total);
+
+            tiledb::Query query(_tiledb_ctx, array);
+            query.set_layout(TILEDB_ROW_MAJOR);
+            query.set_subarray<uint64_t>({0, _n_total - 1});
+            query.set_buffer(ATTRIBUTE_DESC, _buffer);
+            query.set_buffer(ATTRIBUTE_LABEL, _label_ids);
+            query.submit();
+        }
+
+    } catch (tiledb::TileDBError &e) {
+        throw VCLException(TileDBError, "Error: Reading Dense array");
+    }
+
+    _flag_buffer_updated = true;
+}
+
+long TDBDenseDescriptorSet::add(float* descriptors, unsigned n, long* labels)
+{
+    try {
+        std::vector<long> att_label;
+        long* labels_buffer = labels;
+
+        if (labels == NULL) {
+            // By default, labels is -1
+            att_label = std::vector<long> (n, -1);
+            labels_buffer = att_label.data();
+        }
+
+        {
+            tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_WRITE);
+            tiledb::Query query(_tiledb_ctx, array);
+            query.set_layout(TILEDB_ROW_MAJOR);
+            query.set_subarray<uint64_t>({_n_total, _n_total + n-1});
+            query.set_buffer(ATTRIBUTE_DESC, descriptors, n * _dimensions);
+            query.set_buffer(ATTRIBUTE_LABEL, labels_buffer, n);
+            query.submit();
+            query.finalize();
+        }
+    } catch (tiledb::TileDBError &e) {
+        _flag_buffer_updated = false;
+        throw VCLException(UnsupportedOperation, e.what());
+    }
+
+    // Write _n_total into tiledb
+    // This is good because we only write metadata
+    // (_n_total) after the other two writes succedded.
+    _n_total += n;
+    write_metadata();
+
+    // - n becase we already increase _n_total for writing metadata on tdb
+    long old_n_total = _n_total - n;
+
+    _buffer.resize((_n_total) * _dimensions);
+    std::memcpy(&_buffer[old_n_total * _dimensions], descriptors,
+                n * _dimensions * sizeof(float));
+
+    if (labels != NULL) {
+        _label_ids.resize(_n_total);
+        std::memcpy(&_label_ids[old_n_total], labels, n * sizeof(long));
+    }
+
+    return old_n_total;
+}
+
+void TDBDenseDescriptorSet::search(float* query,
+                                      unsigned n_queries, unsigned k,
+                                      long* ids, float* distances)
+{
+    if (!_flag_buffer_updated) {
+        load_buffer();
+    }
+
+    std::vector<float> d(_n_total);
+    std::vector<long> idxs(_n_total);
+
+    for (int i = 0; i < n_queries; ++i) {
+
+        compute_distances(query + i * _dimensions, d, _buffer);
+        std::iota(idxs.begin(), idxs.end(), 0);
+        std::partial_sort(idxs.begin(), idxs.begin() + k, idxs.end(),
+                [&d](size_t i1, size_t i2) { return d[i1] < d[i2]; });
+
+        for (int j = 0; j < k; ++j) {
+            ids      [i * k + j] = idxs[j];
+            distances[i * k + j] = d[idxs[j]];
+        }
+    }
+}
+
+void TDBDenseDescriptorSet::get_descriptors(long* ids, unsigned n,
+                                              float* descriptors)
+{
+    if (!_flag_buffer_updated) {
+        load_buffer();
+    }
+
+    for (int i = 0; i < n; ++i) {
+        long idx = ids[i] * _dimensions;
+        long offset = i *_dimensions;
+        std::memcpy(descriptors + offset, &_buffer[idx],
+                    sizeof(float) * _dimensions);
+    }
+}

--- a/src/TDBDescriptorSet.cc
+++ b/src/TDBDescriptorSet.cc
@@ -1,0 +1,202 @@
+/**
+ * @file   TDBDescriptorSet.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstring>
+
+// By default, we use OMP.
+// #define USE_COMPUTE_MKL
+
+#ifndef USE_COMPUTE_MKL
+#define USE_COMPUTE_OMP
+#endif
+
+#ifdef USE_COMPUTE_MKL
+#include "mkl.h" // INTEL MKL
+#endif
+
+#include "TDBDescriptorSet.h"
+
+#define ATTRIBUTE_NAME "val"
+#define METADATA_PATH "/metadata"
+
+using namespace VCL;
+
+TDBDescriptorSet::TDBDescriptorSet(const std::string &filename):
+    DescriptorSetData(filename)
+{
+    read_labels_map();
+}
+
+TDBDescriptorSet::TDBDescriptorSet(const std::string &filename,
+                                     uint32_t dim):
+    DescriptorSetData(filename, dim)
+{
+}
+
+TDBDescriptorSet::~TDBDescriptorSet()
+{
+}
+
+void TDBDescriptorSet::train()
+{
+    // For now, we just consolidate arrays which
+    // should make the reads faster (according to TileDB docs).
+    // There are more fancy tricks that can be implemented
+    // in the future, specially for the sparse arrays.
+    // Consolidation is needed since many of the insertions done
+    // through TileDB fragments.
+
+    // Consolidate array
+    // tiledb::Array::consolidate(_tiledb_ctx, _set_path);
+}
+
+void TDBDescriptorSet::compute_distances(float* q,
+                                          std::vector<float>& d,
+                                          std::vector<float>& data)
+{
+    size_t n = data.size() / _dimensions;
+
+    float* sub = new float[_dimensions * n];
+
+#ifdef USE_COMPUTE_MKL
+
+    // Intel MKL
+    // #pragma omp parallel for
+    for (int i = 0; i < n; ++i) {
+        size_t idx = i * _dimensions;
+        vsSub(_dimensions, q, data.data() + idx, sub + idx);
+        d[i] = std::pow(cblas_snrm2(_dimensions, sub + idx, 1),2);
+    }
+#endif
+
+#ifdef USE_COMPUTE_OMP
+    // Using RAW OpenMP / This can be optimized
+    #pragma omp parallel for
+    for (int i = 0; i < n; ++i) {
+        size_t idx = i * _dimensions;
+
+        float sum = 0;
+        // #pragma omp parallel for // has to be a reduction
+        for (int j = 0; j < _dimensions; ++j) {
+            sum += std::pow(data[idx + j] - q[j], 2);
+        }
+
+        d[i] = sum; // std::sqrt(sum);
+    }
+#endif
+}
+
+void TDBDescriptorSet::classify(float* descriptors, unsigned n,
+                                   long* labels, unsigned quorum)
+{
+    float* distances = new float[n * quorum];
+    long*  ids_aux   = new long [n * quorum];
+
+    search(descriptors, n, quorum, ids_aux, distances);
+
+    for (int j = 0; j < n; ++j) {
+
+        std::map<long, int> map_voting;
+        long winner = -1;
+        unsigned max = 0;
+        for (int i = 0; i < quorum; ++i) {
+            long idx = ids_aux[quorum*j + i];
+            if (idx < 0)
+                continue; // Means not found
+
+            long label_id = _label_ids.at(idx);
+            map_voting[label_id] += 1;
+            if (max < map_voting[label_id]) {
+                max = map_voting[label_id];
+                winner = label_id;
+            }
+        }
+        labels[j] = winner;
+    }
+}
+
+void TDBDescriptorSet::get_labels(long* ids, unsigned n, long* labels)
+{
+    for (int i = 0; i < n; ++i){
+        labels[i] = _label_ids[ids[i]];
+    }
+}
+
+void TDBDescriptorSet::get_descriptors(long* ids, unsigned n,
+                                       float* descriptors)
+{
+    throw VCLException(UnsupportedOperation,
+                       "get_descriptors Not implemented");
+}
+
+void TDBDescriptorSet::store()
+{
+    write_labels_map();
+}
+
+void TDBDescriptorSet::store(std::string filename)
+{
+    // TODO: Allow user to store in a different file,
+    // which is basically make a copy of the TileDB folder.
+    throw VCLException(UnsupportedOperation, "Unsupported operation");
+}
+
+void TDBDescriptorSet::read_metadata()
+{
+    std::string md_name = _set_path + METADATA_PATH;
+
+    std::vector<std::string> keys;
+    keys.push_back("dimensions");
+    keys.push_back("n_total");
+
+    std::vector<uint64_t*> values;
+    values.push_back((uint64_t*)&_dimensions);
+    values.push_back((uint64_t*)&_n_total);
+
+    TDBObject::read_metadata(md_name, keys, values);
+}
+
+void TDBDescriptorSet::write_metadata()
+{
+    std::vector<std::string> keys;
+    std::vector<uint64_t> values;
+
+    keys.push_back("dimensions");
+    keys.push_back("n_total");
+
+    values.push_back(_dimensions);
+    values.push_back(_n_total);
+
+    TDBObject::write_metadata(_set_path + METADATA_PATH, keys, values);
+}

--- a/src/TDBDescriptorSet.h
+++ b/src/TDBDescriptorSet.h
@@ -1,0 +1,172 @@
+/**
+ * @file   DescriptorSet.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the C++ API for DescriptorSet.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <map>
+
+#include <tiledb/tiledb>
+
+#include "DescriptorSetData.h"
+#include "Exception.h"
+#include "TDBObject.h"
+
+namespace VCL {
+
+    typedef std::vector<float> DescBuffer;
+    typedef std::vector<float> DistanceData;
+
+    class TDBDescriptorSet: public DescriptorSet::DescriptorSetData,
+                               public TDBObject {
+
+    protected:
+        const unsigned long MAX_DESC = 100000;
+
+        tiledb::Context _tiledb_ctx;
+
+        // this is caching data
+        std::vector<long> _label_ids; // we need to move this
+
+        void compute_distances(float* q, DistanceData& d, DescBuffer& data);
+
+        virtual void read_metadata();
+        virtual void write_metadata();
+
+    public:
+
+        /**
+         *  Loads an existing collection located at collection_path
+         *  or created a new collection if it does not exist
+         *
+         *  @param collection_path  Full Path to the collection folder
+         */
+        TDBDescriptorSet(const std::string &collection_path);
+
+        TDBDescriptorSet(const std::string &collection_path, unsigned dim);
+
+        ~TDBDescriptorSet();
+
+        virtual long add(float* descriptors, unsigned n_descriptors, long* classes) = 0;
+
+        virtual void train();
+
+        virtual void train(float* descriptors, unsigned n) { train(); }
+
+        bool is_trained() { return true; }
+
+        virtual void search(float* query, unsigned n_queries, unsigned k,
+                            long* descriptors, float* distances) = 0;
+
+        virtual void classify(float* descriptors, unsigned n, long* labels,
+                              unsigned quorum);
+
+        virtual void get_descriptors(long* ids, unsigned n,
+                                     float* descriptors);
+
+        virtual void get_labels(long* ids, unsigned n, long* labels);
+
+        void store();
+        void store(std::string set_path);
+    };
+
+    class TDBDenseDescriptorSet : public TDBDescriptorSet {
+
+    private:
+
+        const unsigned long METADATA_OFFSET = MAX_DESC - 2;
+
+        // This is for caching, accelerates searches fairly well.
+        bool _flag_buffer_updated;
+        std::vector<float> _buffer;
+
+        void read_metadata();
+        void write_metadata();
+        void load_buffer();
+
+    public:
+        TDBDenseDescriptorSet(const std::string &collection_path);
+
+        TDBDenseDescriptorSet(const std::string &collection_path,
+                                 unsigned dim, DistanceMetric metric);
+
+        ~TDBDenseDescriptorSet();
+
+        long add(float* descriptors, unsigned n_descriptors, long* classes);
+
+        void search(float* query, unsigned n_queries, unsigned k,
+                    long* descriptors, float* distances);
+
+        void get_descriptors(long* ids, unsigned n, float* descriptors);
+    };
+
+    class TDBSparseDescriptorSet : public TDBDescriptorSet {
+
+    private:
+
+        void read_metadata();
+        void write_metadata();
+
+        void load_neighbors(float* query, unsigned k,
+                            std::vector<float>& descriptors,
+                            std::vector<long>& desc_ids,
+                            std::vector<long>& desc_labels);
+
+        void search(float* query, unsigned n_queries, unsigned k,
+                    long* descriptors, float* distances, long* labels);
+
+    public:
+        TDBSparseDescriptorSet(const std::string &collection_path);
+
+        TDBSparseDescriptorSet(const std::string &collection_path,
+                                  unsigned dim, DistanceMetric metric);
+
+        ~TDBSparseDescriptorSet();
+
+        long add(float* descriptors, unsigned n_descriptors, long* classes);
+
+        void search(float* query, unsigned n_queries, unsigned k,
+                    long* descriptors, float* distances);
+
+        void classify(float* descriptors, unsigned n, long* labels,
+                      unsigned quorum);
+
+        void get_descriptors(long* ids, unsigned n, float* descriptors);
+
+        void get_labels(long* ids, unsigned n, long* labels);
+    };
+};

--- a/src/TDBObject.cc
+++ b/src/TDBObject.cc
@@ -43,10 +43,13 @@ using namespace VCL;
     /*        CONSTRUCTORS      */
     /*  *********************** */
 
-TDBObject::TDBObject()
+TDBObject::TDBObject() :
+    _config(NULL),
+    _error(NULL)
 {
     Error_Check(
-        tiledb_ctx_create(&_ctx, NULL), _ctx,
+        tiledb_ctx_alloc(_config, &_ctx),
+        _ctx,
         "TileDB context initialization failed");
 
     _group = "";
@@ -60,16 +63,19 @@ TDBObject::TDBObject()
     _min_tile_dimension = 4;
 }
 
-TDBObject::TDBObject(const std::string &image_id)
+TDBObject::TDBObject(const std::string &object_id) :
+    _config(NULL),
+    _error(NULL)
 {
     Error_Check(
-        tiledb_ctx_create(&_ctx, NULL), _ctx,
+        tiledb_ctx_alloc(_config, &_ctx),
+        _ctx,
         "TileDB context initialization failed");
 
-    size_t pos = get_path_delimiter(image_id);
+    size_t pos = get_path_delimiter(object_id);
 
-    _group = get_group(image_id, pos);
-    _name = get_name(image_id, pos);
+    _group = get_group(object_id, pos);
+    _name = get_name(object_id, pos);
 
     // set default values
     _num_attributes = 1;
@@ -79,23 +85,24 @@ TDBObject::TDBObject(const std::string &image_id)
     _min_tile_dimension = 4;
 }
 
-TDBObject::TDBObject(const TDBObject &tdb)
+TDBObject::TDBObject(const TDBObject &tdb) :
+    _config(NULL),
+    _error(NULL)
 {
     Error_Check(
-        tiledb_ctx_create(&_ctx, NULL), _ctx,
-        "TileDB context initialization failed");
+        tiledb_ctx_alloc(tdb._config, &_ctx),
+        _ctx, "TileDB context initialization failed");
 
     set_equal(tdb);
 }
 
-
 TDBObject& TDBObject::operator=(const TDBObject &tdb)
 {
+    tiledb_ctx_free(&_ctx);
+
     Error_Check(
-        tiledb_ctx_free(&_ctx), _ctx,
-        "TileDB context finalization failed");
-    Error_Check(
-        tiledb_ctx_create(&_ctx, NULL), _ctx,
+        tiledb_ctx_alloc(tdb._config, &_ctx),
+        _ctx,
         "TileDB context initialization failed");
 
     reset_arrays();
@@ -110,6 +117,8 @@ void TDBObject::set_equal(const TDBObject &tdb)
     _group = tdb._group;
 
     _num_attributes = tdb._num_attributes;
+
+    // TODO IS THE FOR NEEDED HERE?
     _attributes.clear();
     for ( int i = 0; i < tdb._attributes.size(); ++i )
         _attributes.push_back(tdb._attributes[i]);
@@ -117,23 +126,27 @@ void TDBObject::set_equal(const TDBObject &tdb)
     _num_dimensions = tdb._num_dimensions;
     _dimension_names.clear();
     _dimension_values.clear();
-    for ( int i = 0; i < tdb._dimension_names.size(); ++i )
-        _dimension_names.push_back(tdb._dimension_names[i]);
-    for ( int i = 0; i < tdb._dimension_values.size(); ++i )
-        _dimension_values.push_back(tdb._dimension_values[i]);
+
+    _dimension_names  = tdb._dimension_names;
+    _dimension_values = tdb._dimension_values;
 
     _compressed = tdb._compressed;
     _min_tile_dimension = tdb._min_tile_dimension;
     _array_dimension = tdb._array_dimension;
     _tile_dimension = tdb._tile_dimension;
+
+    _config = tdb._config;
+    _error = tdb._error;
 }
 
 TDBObject::~TDBObject()
 {
     reset_arrays();
-    Error_Check(
-        tiledb_ctx_free(&_ctx), _ctx,
-        "TileDB context finalization failed");
+
+    if (_error != NULL)
+        tiledb_error_free(&_error);
+
+     tiledb_ctx_free(&_ctx);
 }
 
 void TDBObject::reset_arrays()
@@ -173,7 +186,6 @@ std::string TDBObject::get_object_id() const
     return _group + _name;
 }
 
-
     /*  *********************** */
     /*        SET FUNCTIONS     */
     /*  *********************** */
@@ -185,20 +197,12 @@ void TDBObject::set_num_dimensions(int num)
 
 void TDBObject::set_dimensions(const std::vector<std::string> &dimensions)
 {
-    _dimension_names.clear();
-
-    for ( int x = 0; x < dimensions.size(); ++x ){
-        _dimension_names.push_back(dimensions[x]);
-    }
+    _dimension_names = dimensions;
 }
 
 void TDBObject::set_dimension_values(const std::vector<uint64_t> &dimensions)
 {
-    _dimension_values.clear();
-
-    for ( int x = 0; x < dimensions.size(); ++x ){
-        _dimension_values.push_back(dimensions[x]);
-    }
+    _dimension_values = dimensions;
 }
 
 void TDBObject::set_minimum(int dimension)
@@ -209,14 +213,13 @@ void TDBObject::set_minimum(int dimension)
 void TDBObject::set_num_attributes(int num)
 {
     _num_attributes = num;
-    set_default_attributes();
 }
 
 void TDBObject::set_attributes(const std::vector<std::string> &attributes)
 {
     _attributes.clear();
 
-    for ( int x = 0; x < attributes.size(); ++x ){
+    for (int x = 0; x < attributes.size(); ++x){
         _attributes.push_back(const_cast<char*>(attributes[x].c_str()));
     }
 }
@@ -226,19 +229,16 @@ void TDBObject::set_compression(CompressionType comp)
     _compressed = comp;
 }
 
-
-
-
     /*  *********************** */
     /*  PROTECTED GET FUNCTIONS */
     /*  *********************** */
 
-size_t TDBObject::get_path_delimiter( const std::string &filename ) const
+size_t TDBObject::get_path_delimiter(const std::string &filename) const
 {
     std::string delimiter = "/";
 
     size_t pos = filename.rfind(delimiter);
-    if ( pos == filename.length() - 1 ) {
+    if (pos == filename.length() - 1) {
         std::string file = filename.substr(0, pos);
         pos = file.rfind(delimiter);
     }
@@ -252,9 +252,10 @@ std::string TDBObject::get_group(const std::string &filename, size_t pos) const
 
     tiledb_object_t type;
     Error_Check(
-        tiledb_object_type(_ctx, group.c_str(), &type), 
+        tiledb_object_type(_ctx, group.c_str(), &type),
         _ctx,
         "Type check of " + group + " failed in TileDB");
+
     if ( type != TILEDB_GROUP ) {
         Error_Check(
             tiledb_group_create(_ctx, group.c_str()),
@@ -262,6 +263,7 @@ std::string TDBObject::get_group(const std::string &filename, size_t pos) const
             "Cannot create the TileDB group " + group +
             "; directory may already exist or parent directory is not a TileDB directory");
     }
+
     return group;
 }
 
@@ -271,22 +273,21 @@ std::string TDBObject::get_name(const std::string &filename, size_t pos) const
     return id;
 }
 
-
-
     /*  *********************** */
     /*  PROTECTED SET FUNCTIONS */
     /*  *********************** */
+
 void TDBObject::set_schema_attributes(tiledb_array_schema_t* array_schema, int cell_val_num)
 {
     for (int x = 0; x < _attributes.size(); ++x) {
         tiledb_attribute_t* attr;
         Error_Check(
-            tiledb_attribute_create(_ctx, &attr, _attributes[x], TILEDB_CHAR), 
+            tiledb_attribute_alloc(_ctx, _attributes[x], TILEDB_CHAR, &attr),
             _ctx,
-            "TileDB failed to create attribute");
+            "TileDB failed to alloc attribute");
         tiledb_compressor_t compressor = convert_to_tiledb();
         Error_Check(
-            tiledb_attribute_set_compressor(_ctx, attr, compressor, -1), 
+            tiledb_attribute_set_compressor(_ctx, attr, compressor, -1),
             _ctx,
             "TileDB failed to set attribute information");
         Error_Check(
@@ -298,9 +299,8 @@ void TDBObject::set_schema_attributes(tiledb_array_schema_t* array_schema, int c
             tiledb_array_schema_add_attribute(_ctx, array_schema, attr),
             _ctx,
             "TileDB failed to add attribute to schema");
-        Error_Check(
-            tiledb_attribute_free(_ctx, &attr), _ctx,
-            "TileDB failed to free attribute object");
+
+        tiledb_attribute_free(&attr);
     }
 }
 
@@ -308,8 +308,8 @@ void TDBObject::set_schema_dimensions(tiledb_array_schema_t* array_schema)
 {
     tiledb_domain_t* domain;
     Error_Check(
-        tiledb_domain_create(_ctx, &domain), _ctx,
-        "TileDB failed to create domain object");
+        tiledb_domain_alloc(_ctx, &domain), _ctx,
+        "TileDB failed to alloc domain object");
 
     find_tile_extents();
 
@@ -326,33 +326,31 @@ void TDBObject::set_schema_dimensions(tiledb_array_schema_t* array_schema)
         tiledb_dimension_t* dim;
 
         Error_Check(
-            tiledb_dimension_create(_ctx, &dim, _dimension_names[x].c_str(), 
-                TILEDB_UINT64, cur_domain, &_tile_dimension[x]),
+            tiledb_dimension_alloc(_ctx, _dimension_names[x].c_str(),
+                TILEDB_UINT64, cur_domain, &_tile_dimension[x], &dim),
             _ctx,
             "TileDB failed to create dimension " + _dimension_names[x]);
 
         Error_Check(
             tiledb_domain_add_dimension(_ctx, domain, dim), _ctx,
             "TileDB failed to add dimension " + _dimension_names[x]);
-        Error_Check(
-            tiledb_dimension_free(_ctx, &dim), _ctx,
-            "TileDB failed to create dimension " + _dimension_names[x]);
+
+        tiledb_dimension_free(&dim);
     }
 
     Error_Check(
         tiledb_array_schema_set_domain(_ctx, array_schema, domain),
         _ctx,
         "TileDB failed to set domain");
-    Error_Check(
-        tiledb_domain_free(_ctx, &domain), _ctx,
-        "TileDB failed to free domain object");
+
+    tiledb_domain_free(&domain);
 }
 
 void TDBObject::set_schema_dense(int cell_val_num, const std::string& object_id)
 {
     tiledb_array_schema_t* array_schema;
     Error_Check(
-        tiledb_array_schema_create(_ctx, &array_schema, TILEDB_DENSE),
+        tiledb_array_schema_alloc(_ctx, TILEDB_DENSE, &array_schema),
         _ctx,
         "TileDB failed to create array schema for " + object_id);
     set_schema(cell_val_num, object_id, array_schema);
@@ -362,7 +360,7 @@ void TDBObject::set_schema_sparse(int cell_val_num, const std::string& object_id
 {
     tiledb_array_schema_t* array_schema;
     Error_Check(
-        tiledb_array_schema_create(_ctx, &array_schema, TILEDB_SPARSE),
+        tiledb_array_schema_alloc(_ctx, TILEDB_SPARSE, &array_schema),
         _ctx,
         "TileDB failed to create array schema for " + object_id);
     set_schema(cell_val_num, object_id, array_schema);
@@ -396,22 +394,18 @@ void TDBObject::set_schema(int cell_val_num, const std::string& object_id, tiled
         Error_Check(
             tiledb_array_create(_ctx, object_id.c_str(), array_schema),
             _ctx,
-            "Cannot create the TileDB array " + object_id + 
+            "Cannot create the TileDB array " + object_id +
             "; array may already exist or parent directory is not a TileDB directory");
-        }
+    }
 
-    Error_Check(
-        tiledb_array_schema_free(_ctx, &array_schema),
-        _ctx,
-        "TileDB schema failed to be freed");
+    tiledb_array_schema_free(&array_schema);
 }
-
 
 void TDBObject::set_from_schema(const std::string &object_id)
 {
     tiledb_array_schema_t* array_schema;
     Error_Check(
-        tiledb_array_schema_load(_ctx, &array_schema, object_id.c_str()),
+        tiledb_array_schema_load(_ctx, object_id.c_str(), &array_schema),
         _ctx,
         "TileDB schema retrieval failed");
 
@@ -429,7 +423,7 @@ void TDBObject::set_from_schema(const std::string &object_id)
         "TileDB failed to retrieve domain from schema");
     unsigned dim_num;
     Error_Check(
-        tiledb_domain_get_rank(_ctx, domain, &dim_num),
+        tiledb_domain_get_ndim(_ctx, domain, &dim_num),
         _ctx,
         "TileDB failed to get dimension number from domain");
     _num_dimensions = dim_num;
@@ -458,39 +452,96 @@ void TDBObject::set_from_schema(const std::string &object_id)
         uint64_t* dom_tui64 = static_cast<uint64_t*>(domainptr);
         _array_dimension.push_back(dom_tui64[1] + 1);
 
-        Error_Check(
-            tiledb_dimension_free(_ctx, &dim), _ctx,
-            "TileDB failed to free dimension object");
+        tiledb_dimension_free(&dim);
     }
 
-    Error_Check(
-        tiledb_domain_free(_ctx, &domain), _ctx,
-        "TileDB failed to free domain object");
+    tiledb_domain_free(&domain);
 
-    Error_Check(
-        tiledb_array_schema_free(_ctx, &array_schema),
-        _ctx,
-        "TileDB schema failed to be freed");
+    tiledb_array_schema_free(&array_schema);
 }
-
 
     /*  *********************** */
     /*   METADATA INTERACTION   */
     /*  *********************** */
 
-void TDBObject::write_metadata(const std::string &metadata, const std::vector<std::string> &keys, 
-            const std::vector<uint64_t> &values)
+// NOTE: This method assumes uint64_t as the data type in the
+// TileDB KeyValue map. This works well for Images and DescriptorSet
+// as all the used metadata is uint64_t.
+// In the future, if there is a need and
+// we include other type of metadata, this can be a templated function.
+
+void TDBObject::read_metadata(const std::string &metadata,
+                              const std::vector<std::string> &keys,
+                              const std::vector<uint64_t *> &values)
+{
+    tiledb_kv_t* metadata_kv;
+
+    tiledb_object_t md_type;
+    tiledb_object_type(_ctx, metadata.c_str(), &md_type);
+    if ( md_type != TILEDB_KEY_VALUE )
+        throw VCLException(TileDBNotFound, "Not a TileDB KeyValue");
+
+    Error_Check(
+        tiledb_kv_alloc(_ctx, metadata.c_str(), &metadata_kv),
+        _ctx,
+        "TileDB metadata allocation failed");
+
+    Error_Check(
+        tiledb_kv_open(_ctx, metadata_kv, NULL, 0),
+        _ctx,
+        "TileDB metadata failed to open");
+
+    const char* key = _name.c_str();
+    tiledb_datatype_t key_type = TILEDB_CHAR;
+    uint64_t key_size = std::strlen(key);
+
+    tiledb_kv_item_t* kv_item = NULL;
+    Error_Check(
+        tiledb_kv_get_item(_ctx, metadata_kv, key, key_type, key_size, &kv_item),
+        _ctx,
+        "TileDB cannot retrieve metadata object");
+
+    if (kv_item == nullptr) {
+        throw VCLException(TileDBError, "TileDB metadata error");
+    }
+
+    for (int i = 0; i < keys.size(); ++i) {
+        const void *val;
+        tiledb_datatype_t val_type;
+        uint64_t val_size;
+
+        Error_Check(
+            tiledb_kv_item_get_value(_ctx, kv_item, keys[i].c_str(),
+                &val, &val_type, &val_size),
+            _ctx,
+            "TileDB cannot retrieve height from metadata");
+
+        *(values[i]) = *((const uint64_t*)val);
+    }
+
+    Error_Check(
+        tiledb_kv_close(_ctx, metadata_kv),
+        _ctx,
+        "TileDB metadata failed to close");
+
+
+    tiledb_kv_item_free(&kv_item);
+}
+
+void TDBObject::write_metadata(const std::string &metadata,
+                               const std::vector<std::string> &keys,
+                               const std::vector<uint64_t> &values)
 {
     tiledb_kv_schema_t* kv_schema;
     Error_Check(
-        tiledb_kv_schema_create(_ctx, &kv_schema),
+        tiledb_kv_schema_alloc(_ctx, &kv_schema),
         _ctx,
         "TileDB failed to create metadata schema");
 
     for (int i = 0; i < keys.size(); ++i) {
         tiledb_attribute_t* attr;
         Error_Check(
-            tiledb_attribute_create(_ctx, &attr, keys[i].c_str(), TILEDB_UINT64),
+            tiledb_attribute_alloc(_ctx, keys[i].c_str(), TILEDB_UINT64, &attr),
             _ctx,
             "TileDB failed to create metadata attribute");
         Error_Check(
@@ -505,9 +556,8 @@ void TDBObject::write_metadata(const std::string &metadata, const std::vector<st
             tiledb_kv_schema_add_attribute(_ctx, kv_schema, attr),
             _ctx,
             "TileDB failed to add metadata attribute to metadata schema");
-        Error_Check(
-            tiledb_attribute_free(_ctx, &attr), _ctx,
-            "TileDB failed to free metadata attribute");
+
+        tiledb_attribute_free(&attr);
     }
 
     Error_Check(
@@ -519,6 +569,7 @@ void TDBObject::write_metadata(const std::string &metadata, const std::vector<st
         tiledb_object_type(_ctx, metadata.c_str(), &type),
         _ctx,
         "TileDB object check of " + metadata + " failed");
+
     if ( type != TILEDB_KEY_VALUE ) {
         Error_Check(
             tiledb_kv_create(_ctx, metadata.c_str(), kv_schema),
@@ -527,15 +578,14 @@ void TDBObject::write_metadata(const std::string &metadata, const std::vector<st
             "; directory may already exist or parent directory is not a TileDB directory");
     }
 
-    Error_Check(
-        tiledb_kv_schema_free(_ctx, &kv_schema), _ctx,
-        "TileDB schema failed to be freed");
+    tiledb_kv_schema_free(&kv_schema);
 
     tiledb_kv_item_t* kv_item;
     const char* keyname = _name.c_str();
     Error_Check(
-        tiledb_kv_item_create(_ctx, &kv_item), _ctx,
-        "TileDB failed to create metadata item");
+        tiledb_kv_item_alloc(_ctx, &kv_item), _ctx,
+        "TileDB failed to alloc metadata item");
+
     Error_Check(
         tiledb_kv_item_set_key(_ctx, kv_item, keyname, TILEDB_CHAR, std::strlen(keyname)),
         _ctx,
@@ -549,25 +599,28 @@ void TDBObject::write_metadata(const std::string &metadata, const std::vector<st
             _ctx,
             "TileDB failed to set metadata value");
     }
-    
+
     tiledb_kv_t* kv;
 
-    Error_Check( 
-        tiledb_kv_open(_ctx, &kv, metadata.c_str(), NULL, 0),
+    Error_Check(
+        tiledb_kv_alloc(_ctx, metadata.c_str(), &kv),
+        _ctx,
+        "TileDB metadata allocation failed");
+     Error_Check(
+        tiledb_kv_open(_ctx, kv, NULL, 0),
         _ctx,
         "TileDB metadata open failed");
 
-    Error_Check( 
+    Error_Check(
         tiledb_kv_add_item(_ctx, kv, kv_item), _ctx,
         "TileDB metadata failed to write");
 
-    Error_Check( 
-        tiledb_kv_close(_ctx, &kv), _ctx,
+    Error_Check(
+        tiledb_kv_close(_ctx, kv), _ctx,
         "TileDB metadata failed to close");
 
-    Error_Check(
-        tiledb_kv_item_free(_ctx, &kv_item), _ctx,
-        "TileDB failed to free metadata item");
+    tiledb_kv_item_free(&kv_item);
+    tiledb_kv_free(&kv);
 }
 
 void TDBObject::find_tile_extents()
@@ -579,7 +632,7 @@ void TDBObject::find_tile_extents()
         int num_tiles = 0;
 
         int gf_dimension = greatest_factor(dimension);
-        
+
         while ( gf_dimension == 1 ) {
             dimension = dimension + 1;
             gf_dimension = greatest_factor(dimension);
@@ -624,13 +677,13 @@ tiledb_compressor_t TDBObject::convert_to_tiledb()
     }
 }
 
-
     /*  *********************** */
     /*   PRIVATE FUNCTIONS      */
     /*  *********************** */
+
 void TDBObject::set_types(int* types)
 {
-    for ( int i = 0; i < _num_attributes; ++i ){
+    for ( int i = 0; i < _num_attributes; ++i ) {
         types[i] = TILEDB_CHAR;
     }
 }
@@ -640,15 +693,10 @@ int TDBObject::greatest_factor(int a)
     int b = a;
 
     while (b > 1) {
-//        --b;
-       if (a % b == 0 && a / b >= _min_tile_dimension)
-       {
+       if (a % b == 0 && a / b >= _min_tile_dimension) {
            return b;
        }
        --b;
     }
     return b;
 }
-
-
-

--- a/src/TDBObject.h
+++ b/src/TDBObject.h
@@ -55,7 +55,6 @@ namespace VCL {
             tiledb_ctx_get_last_error(ctx, &err);
             const char* msg;
             tiledb_error_message(err, &msg);
-            // printf("%s\n", msg);
             std::string full_err_msg = message + "\n" + std::string(msg);
             throw VCLException(TileDBError, full_err_msg);
         }
@@ -88,6 +87,9 @@ namespace VCL {
         std::vector<uint64_t> _array_dimension;
         std::vector<uint64_t> _tile_dimension;
         tiledb_ctx_t* _ctx;
+
+        tiledb_config_t* _config;
+        tiledb_error_t* _error;
 
     public:
 
@@ -175,18 +177,13 @@ namespace VCL {
         void set_minimum(int dimension);
 
         /**
-         *  Implemented by the specific TDBObject classes, sets
-         *    the names of the dimensions to standard defaults
-         */
-        virtual void set_default_dimensions() = 0;
-
-        /**
          *  Sets the number of attributes in the TDBObject, which defines
          *    how the array is stored. Default is usually one
          *
          *  @param num_attributes  The number of attributes
          */
         void set_num_attributes(int num_attributes);
+
         /**
          *  Sets the names of attributes in the TDBObject
          *
@@ -194,12 +191,6 @@ namespace VCL {
          *    names of the attributes
          */
         void set_attributes(const std::vector<std::string> &attributes);
-
-        /**
-         *  Implemented by the specific TDBObject classes, sets
-         *    the names of the attributes to standard defaults
-         */
-        virtual void set_default_attributes() = 0;
 
         /**
          *  Sets the type of compression to be used when compressing
@@ -214,26 +205,11 @@ namespace VCL {
     /*  *********************** */
     /*  TDBOBJECT INTERACTION   */
     /*  *********************** */
-        /**
-         *  Implemented by the specific TDBObject class, writes the data in
-         *    the TDBObject to the given object id
-         *
-         *  @param object_id  The object id where the data is to be written
-         *  @param  metadata  A flag indicating whether the metadata
-         *    should be stored in TileDB or not. Defaults to true
-         */
-        virtual void write(const std::string &object_id, bool metadata = true) = 0;
 
-        /**
-         *  Implemented by the specific TDBObject class, reads the data from
-         *    the TDBObject specified by the path variables
-         */
-        virtual void read() = 0;
-
-        /**
-         *  Deletes the object from TileDB
-         */
-        void delete_object();
+    /**
+     *  Deletes the object from TileDB
+     */
+    void delete_object();
 
 
 
@@ -288,7 +264,7 @@ namespace VCL {
          *  @param  object_id  The full path to the TileDB array
          */
         void set_schema_dense(int cell_val_num, const std::string &object_id);
-        
+
         /**
          *  Determines the TileDB schema variables and sets the
          *    schema for writing a sparse TileDB array
@@ -297,7 +273,7 @@ namespace VCL {
          *  @param  object_id  The full path to the TileDB array
          */
         void set_schema_sparse(int cell_val_num, const std::string &object_id);
-        
+
         /**
          *  Sets the TDBObject values from an array schema
          *
@@ -308,6 +284,7 @@ namespace VCL {
     /*  *********************** */
     /*   METADATA INTERACTION   */
     /*  *********************** */
+
         /**
          *  Writes the TDBObject metadata
          *
@@ -315,14 +292,17 @@ namespace VCL {
          *  @param  keys  A vector containing the metadata keys
          *  @param  values  A vector containing the metadata values
          */
-        void write_metadata(const std::string &metadata, const std::vector<std::string> &keys, 
-            const std::vector<uint64_t> &values);
+        void write_metadata(const std::string &metadata,
+                            const std::vector<std::string> &keys,
+                            const std::vector<uint64_t> &values);
 
         /**
          *  Implemented by the specific TDBObject class, reads the
          *    metadata associated with the TDBObject
          */
-        virtual void read_metadata() = 0;
+        void read_metadata(const std::string &metadata,
+                           const std::vector<std::string> &keys,
+                           const std::vector<uint64_t*> &values);
 
     private:
         /**
@@ -342,7 +322,6 @@ namespace VCL {
          */
         int greatest_factor(int a);
 
-
         /**
          *  Resets the arrays that are members of this class
          */
@@ -361,16 +340,18 @@ namespace VCL {
          *  @param array_schema  The TileDB array schema
          *  @param cell_val_num  The number of values per cell
          */
-        void set_schema_attributes(tiledb_array_schema_t* array_schema, int cell_val_num);
+        void set_schema_attributes(tiledb_array_schema_t* array_schema,
+                                   int cell_val_num);
 
         /**
-         *  Sets the TileDB schema 
+         *  Sets the TileDB schema
          *
          *  @param cell_val_num  The number of values per cell
          *  @param object_id  The full path to the TileDB array
          *  @param array_schema  The TileDB array schema
          */
-        void set_schema(int cell_val_num, const std::string &object_id, tiledb_array_schema_t* array_schema);
+        void set_schema(int cell_val_num, const std::string &object_id,
+                        tiledb_array_schema_t* array_schema);
 
         /**
          *  Converts the VCL CompressionType to TileDB compression

--- a/src/TDBSparseDescriptorSet.cc
+++ b/src/TDBSparseDescriptorSet.cc
@@ -1,0 +1,472 @@
+/**
+ * @file   TDBSparseDescriptorSet.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstring>
+
+#include "TDBDescriptorSet.h"
+#include <tiledb/tiledb.h>
+
+#define ATTRIBUTE_SPARSE_ID     "id"
+#define ATTRIBUTE_SPARSE_LABEL "label"
+
+#define DIMENSION_LOWER_LIMIT -10000
+#define DIMENSION_UPPER_LIMIT 10000
+#define DIMENSION_TILE_SIZE 250
+
+using namespace VCL;
+
+TDBSparseDescriptorSet::TDBSparseDescriptorSet(const std::string &filename):
+    TDBDescriptorSet(filename)
+{
+    _name = "unnecessary_name";
+    read_metadata();
+}
+
+TDBSparseDescriptorSet::TDBSparseDescriptorSet(
+                    const std::string &filename,
+                    uint32_t dim,
+                    DistanceMetric metric):
+    TDBDescriptorSet(filename, dim)
+{
+    _name = "unnecessary_name";
+    tiledb::Domain domain(_tiledb_ctx);
+
+    for (int i = 0; i < _dimensions; ++i) {
+        std::string dim_name = "dim_" + std::to_string(i);
+
+        float lower_limit = DIMENSION_LOWER_LIMIT;
+        float upper_limit = DIMENSION_UPPER_LIMIT;
+
+        if (i == 0) {
+            // First dimension is incresed to store metadata,
+            // as descriptors will always have at least 1 dim.
+            upper_limit = upper_limit + DIMENSION_TILE_SIZE;
+        }
+
+        auto d = tiledb::Dimension::create<float>(
+                        _tiledb_ctx, dim_name.c_str(), {
+                        {lower_limit, upper_limit}}, DIMENSION_TILE_SIZE);
+        // TODO: The domains can be set based on the distribution
+        // of the data, which can be moved to trai() fuction in the future.
+        domain.add_dimension(d);
+    }
+
+    tiledb::Attribute att_id = tiledb::Attribute::create<long>(_tiledb_ctx, ATTRIBUTE_SPARSE_ID);
+    att_id.set_compressor({TILEDB_BLOSC_LZ, -1});
+
+    tiledb::Attribute att_label = tiledb::Attribute::create<long>(_tiledb_ctx, ATTRIBUTE_SPARSE_LABEL);
+    att_label.set_compressor({TILEDB_BLOSC_LZ, -1});
+
+    tiledb::ArraySchema schema(_tiledb_ctx, TILEDB_SPARSE);
+    schema.set_tile_order(TILEDB_ROW_MAJOR).set_cell_order(TILEDB_ROW_MAJOR);
+    schema.set_capacity(100);
+    schema.set_domain(domain);
+    schema.add_attribute(att_id);
+    schema.add_attribute(att_label);
+
+    try {
+        schema.check();
+    } catch (tiledb::TileDBError &e) {
+        throw VCLException(TileDBError, "Error setting TileDB Schema");
+    }
+
+    tiledb::Array::create(_set_path, schema);
+}
+
+void TDBSparseDescriptorSet::write_metadata()
+{
+    std::vector<float> coords(_dimensions, DIMENSION_UPPER_LIMIT);
+    coords[0] += 1.0f;
+
+    long dims = _dimensions;
+    long n_total = _n_total;
+    // We use the ID attribute to store _dimension
+    // and the LABEL attibute to store _n_total;
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_WRITE);
+    tiledb::Query query(_tiledb_ctx, array);
+    query.set_layout(TILEDB_GLOBAL_ORDER);
+    query.set_buffer(ATTRIBUTE_SPARSE_ID, &dims, 1);
+    query.set_buffer(ATTRIBUTE_SPARSE_LABEL, &n_total, 1);
+    query.set_buffer(TILEDB_COORDS, coords);
+    query.submit();
+    query.finalize();
+    array.close();
+}
+
+void TDBSparseDescriptorSet::read_metadata()
+{
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_READ);
+
+    std::vector<float> coords(_dimensions * 2, DIMENSION_UPPER_LIMIT);
+    coords[0] += 1.0f;
+    coords[1] += 1.0f;
+
+    auto max_sizes = array.max_buffer_elements(coords);
+
+    // Prepare cell buffers
+    std::vector<long> desc_ids(max_sizes[ATTRIBUTE_SPARSE_ID].second);
+    std::vector<long> desc_labels(max_sizes[ATTRIBUTE_SPARSE_LABEL].second);
+
+    tiledb::Query query(_tiledb_ctx, array);
+    query.set_layout(TILEDB_ROW_MAJOR).set_subarray(coords);
+    query.set_buffer(ATTRIBUTE_SPARSE_ID, desc_ids);
+    query.set_buffer(ATTRIBUTE_SPARSE_LABEL, desc_labels);
+    query.submit();
+
+    auto result_el = query.result_buffer_elements();
+    long found = result_el[ATTRIBUTE_SPARSE_ID].second;
+
+    assert(found == 1);
+
+    _dimensions = desc_ids[0];
+    _n_total = desc_labels[0];
+
+    array.close();
+}
+
+long TDBSparseDescriptorSet::add(float* descriptors, unsigned n, long* labels)
+{
+    try {
+        std::vector<long> att_id(n);
+        std::iota(att_id.begin(), att_id.end(), _n_total);
+
+        std::vector<long> att_label;
+
+        long* labels_for_query = labels;
+
+        if (labels == NULL) {
+            // By default, labels is -1
+            att_label = std::vector<long> (n, -1);
+            labels_for_query = att_label.data();
+        }
+
+        {
+            tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_WRITE);
+            tiledb::Query query(_tiledb_ctx, array);
+            query.set_layout(TILEDB_GLOBAL_ORDER);
+            query.set_buffer(ATTRIBUTE_SPARSE_ID, att_id);
+            query.set_buffer(ATTRIBUTE_SPARSE_LABEL, labels_for_query, n);
+            query.set_buffer(TILEDB_COORDS, descriptors, n * _dimensions);
+            query.submit();
+            query.finalize();
+            array.close();
+        }
+    } catch (tiledb::TileDBError &e) {
+        throw VCLException(UnsupportedOperation, "TileDBError, check logs");
+    }
+
+    write_metadata();
+    _n_total += n;
+    return _n_total - n;
+}
+
+void TDBSparseDescriptorSet::load_neighbors(float* q, unsigned k,
+                                        std::vector<float>& descriptors,
+                                        std::vector<long>& desc_ids,
+                                        std::vector<long>& desc_labels)
+{
+    bool flag_found = true;
+    long found = 0;
+    int attempt = 0;
+
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_READ);
+
+    while (found < k) {
+
+        // Calculate maximum buffer elements for the
+        // query results per attribute
+
+        std::vector<float> subarray(_dimensions * 2);
+
+        float space = std::pow(2, 4 + attempt++);
+
+        if (space >= (DIMENSION_UPPER_LIMIT - DIMENSION_LOWER_LIMIT) / 2) {
+            flag_found = false;
+            break;
+        }
+
+        #pragma omp parallel for
+        for (int i = 0; i < _dimensions; ++i) {
+            subarray[2*i+0] = (q[i] - space) > DIMENSION_LOWER_LIMIT ?
+                              (q[i] - space) : DIMENSION_LOWER_LIMIT;
+            subarray[2*i+1] = (q[i] + space) < DIMENSION_UPPER_LIMIT ?
+                              (q[i] + space) : DIMENSION_UPPER_LIMIT;
+        }
+
+        auto max_sizes = array.max_buffer_elements(subarray);
+
+        // Prepare cell buffers
+        descriptors.resize(max_sizes[TILEDB_COORDS].second);
+        desc_ids.resize(max_sizes[ATTRIBUTE_SPARSE_ID].second);
+        desc_labels.resize(max_sizes[ATTRIBUTE_SPARSE_LABEL].second);
+
+        // Create query
+        tiledb::Query query(_tiledb_ctx, array);
+        query.set_layout(TILEDB_ROW_MAJOR).set_subarray(subarray);
+        query.set_buffer(ATTRIBUTE_SPARSE_LABEL, desc_labels);
+        query.set_buffer(ATTRIBUTE_SPARSE_ID, desc_ids);
+        query.set_buffer(TILEDB_COORDS, descriptors);
+
+        // Submit query
+        query.submit();
+
+        auto result_el = query.result_buffer_elements();
+        found = result_el[ATTRIBUTE_SPARSE_ID].second;
+
+        descriptors.resize(found * _dimensions);
+        desc_ids.resize(found);
+        desc_labels.resize(found);
+    }
+
+    array.close();
+
+    if (flag_found == false) {
+       desc_ids.clear();
+       desc_labels.clear();
+       descriptors.clear();
+    }
+}
+
+void TDBSparseDescriptorSet::classify(float* descriptors, unsigned n,
+                                         long* labels, unsigned quorum)
+{
+    float* distances  = new float[n * quorum];
+    long*  ids_aux    = new long [n * quorum];
+    long*  labels_aux = new long [n * quorum];
+
+    search(descriptors, n, quorum, ids_aux, distances, labels_aux);
+
+    for (int j = 0; j < n; ++j) {
+
+        std::map<long, int> map_voting;
+        long winner = -1;
+        unsigned max = 0;
+        for (int i = 0; i < quorum; ++i) {
+            long idx = ids_aux[quorum*j + i];
+            if (idx < 0)
+                continue; // Means not found
+
+            long label_id = labels_aux[quorum*j + i];
+            map_voting[label_id] += 1;
+            if (max < map_voting[label_id]) {
+                max = map_voting[label_id];
+                winner = label_id;
+            }
+        }
+        labels[j] = winner;
+    }
+}
+
+void TDBSparseDescriptorSet::search(float* query, unsigned n, unsigned k,
+                                    long* ids, float* distances, long* labels)
+{
+    std::vector<float> descs;
+    std::vector<long>  desc_ids;
+    std::vector<long>  desc_labels;
+
+    for (int i = 0; i < n; ++i) {
+
+        load_neighbors(query + i * _dimensions, k, descs, desc_ids, desc_labels);
+        unsigned found = desc_ids.size();
+
+        std::vector<float> d(found);
+        std::vector<long> idxs(found);
+
+        compute_distances(query + i * _dimensions, d, descs);
+
+        std::iota(idxs.begin(), idxs.end(), 0);
+        std::partial_sort(idxs.begin(), idxs.begin() + k, idxs.end(),
+                [&d](size_t i1, size_t i2) { return d[i1] < d[i2]; });
+
+        for (int j = 0; j < std::min(k, found); ++j) {
+            ids      [i * k + j] = desc_ids[idxs[j]];
+            distances[i * k + j] = d[idxs[j]];
+        }
+
+        if ( k > found) {
+            for (int j = found; j < k; ++j) {
+                ids      [i * k + j] = -1;
+                distances[i * k + j] = -1;
+            }
+        }
+
+        // Include labels, needed for faster classify
+        // because it already gets the labels from the load_neighbor()
+        if (labels != NULL) {
+            for (int j = 0; j < std::min(k, found); ++j) {
+                labels   [i * k + j] = desc_labels[idxs[j]];
+            }
+
+            if ( k > found) {
+                for (int j = found; j < k; ++j) {
+                    labels   [i * k + j] = -1;
+                }
+            }
+        }
+    }
+}
+
+void TDBSparseDescriptorSet::search(float* query, unsigned n, unsigned k,
+                                       long* ids, float* distances)
+{
+    search(query, n, k, ids, distances, NULL);
+}
+
+void TDBSparseDescriptorSet::get_descriptors(long* ids, unsigned n,
+                                                float* descriptors)
+{
+    std::vector<float> subarray(_dimensions * 2);
+
+    float space = 20;
+
+    #pragma omp parallel for
+    for (int i = 0; i < _dimensions; ++i) {
+        subarray[2*i+0] = DIMENSION_LOWER_LIMIT;
+        subarray[2*i+1] = DIMENSION_UPPER_LIMIT;
+    }
+
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_READ);
+    auto max_sizes = array.max_buffer_elements(subarray);
+
+    // Prepare cell buffers
+    std::vector<float> buffer;
+    buffer.resize(max_sizes[TILEDB_COORDS].second);
+    std::vector<long>  desc_ids;
+    desc_ids.resize(max_sizes[ATTRIBUTE_SPARSE_ID].second);
+
+    // Create query
+    tiledb::Query query(_tiledb_ctx, array);
+    query.set_layout(TILEDB_ROW_MAJOR);
+    query.set_subarray(subarray);
+    query.set_buffer(ATTRIBUTE_SPARSE_ID, desc_ids);
+    query.set_buffer(TILEDB_COORDS, buffer);
+
+    // Submit query
+    query.submit();
+
+    // Print cell values (assumes all attributes are read)
+    auto result_el = query.result_buffer_elements();
+    unsigned n_found = result_el[ATTRIBUTE_SPARSE_ID].second;
+
+    buffer.resize(n_found * _dimensions);
+    desc_ids.resize(n_found);
+
+    // This is the worst algorithm ever, EVER.
+    // This is O(n), can be implemented using a binary search.
+    // We need to sort the desc_ids for this, need a trade off.
+
+    for (int i = 0; i < n; ++i) {
+        long offset = i *_dimensions;
+        long id_q = ids[i];
+        bool found = false;
+
+        for (int j = 0; j < desc_ids.size(); ++j) {
+            if (id_q == desc_ids[j]) {
+                std::memcpy(descriptors + offset,
+                            &buffer[j * _dimensions],
+                            sizeof(float) * _dimensions);
+                found = true;
+                break;
+            }
+        }
+
+        if (found) {
+            continue;
+        }
+
+        for (int j = 0; j < _dimensions; ++j) {
+            descriptors[offset+j] = -1;
+        }
+    }
+}
+
+void TDBSparseDescriptorSet::get_labels(long* ids, unsigned n, long* labels)
+{
+    std::vector<float> subarray(_dimensions * 2);
+
+    #pragma omp parallel for
+    for (int i = 0; i < _dimensions; ++i) {
+        subarray[2*i+0] = DIMENSION_LOWER_LIMIT;
+        subarray[2*i+1] = DIMENSION_UPPER_LIMIT;
+    }
+
+    tiledb::Array array(_tiledb_ctx, _set_path, TILEDB_READ);
+    auto max_sizes = array.max_buffer_elements(subarray);
+
+    // Prepare cell buffers
+    std::vector<long>  desc_ids;
+    desc_ids.resize(max_sizes[ATTRIBUTE_SPARSE_ID].second);
+    std::vector<long>  desc_labels;
+    desc_labels.resize(max_sizes[ATTRIBUTE_SPARSE_LABEL].second);
+
+    // Create query
+    tiledb::Query query(_tiledb_ctx, array);
+    query.set_layout(TILEDB_ROW_MAJOR).set_subarray(subarray);
+    query.set_buffer(ATTRIBUTE_SPARSE_LABEL, desc_labels);
+    query.set_buffer(ATTRIBUTE_SPARSE_ID, desc_ids);
+
+    // Submit query
+    query.submit();
+
+    // Print cell values (assumes all attributes are read)
+    auto result_el = query.result_buffer_elements();
+    unsigned n_found = result_el[ATTRIBUTE_SPARSE_ID].second;
+
+    desc_ids.resize(n_found);
+    desc_labels.resize(n_found);
+
+    // This is the worst algo ever, EVER.
+    // This is O(n), can be implemented using a binary search.
+    // We need to sort the desc_ids for this, need a trade off.
+
+    for (int i = 0; i < n; ++i) {
+        long offset = i *_dimensions;
+        long id_q = ids[i];
+        bool found = false;
+
+        for (int j = 0; j < desc_ids.size(); ++j) {
+            if (id_q == desc_ids[j]) {
+                labels[i] = desc_labels[j];
+                found = true;
+                break;
+            }
+        }
+
+        if (found) {
+            continue;
+        }
+
+        labels[i] = -1;
+    }
+}

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -1,0 +1,36 @@
+test_env = Environment(CPPPATH= ['/opt/intel/vcl/include/',
+                                 '/opt/intel/vcl/src/',
+                                 '/opt/intel/vdms/include/',
+                                ],
+                      CXXFLAGS= "-std=c++11 -O3")
+
+test_env.Program('main',
+        [
+        'unit_tests/main.cc',
+        'unit_tests/helpers.cc',
+        'unit_tests/TDBImage_test.cc',
+        'unit_tests/ImageData_test.cc',
+        'unit_tests/Image_test.cc',
+        'unit_tests/DescriptorSetAdd_test.cc',
+        'unit_tests/DescriptorSetClassify_test.cc',
+        'unit_tests/DescriptorSetTrain_test.cc',
+        'unit_tests/DescriptorSetReadFS_test.cc',
+        'unit_tests/DescriptorSetStore_test.cc',
+         ],
+
+        LIBS = ['tiledb',
+                'opencv_core',
+                'opencv_imgproc',
+                'opencv_imgcodecs',
+                'gomp',
+                'faiss',
+                'vcl', 'gtest', 'pthread',
+                 ],
+
+        LIBPATH = ['/usr/local/lib/', '../',
+                   '/opt/facebook/faiss',
+                   '/opt/intel/mkl/lib/intel64/'
+                   ],
+
+        LINKFLAGS="-Wl,--no-as-needed",
+    )

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,9 @@
+# Cleanup
+rm -r tdb
+rm -r dbs
+mkdir dbs # necessary for Descriptors
+
+# Compile and run tests
+scons -j16
+
+./main

--- a/test/unit_tests/DescriptorSetAdd_test.cc
+++ b/test/unit_tests/DescriptorSetAdd_test.cc
@@ -1,0 +1,781 @@
+/**
+ * @file   DescriptorSetAdd_test.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <cmath>
+#include <list>
+
+#include "VCL.h"
+#include "helpers.h"
+#include "gtest/gtest.h"
+
+TEST(Descriptors_Add, add_flatl2_100d)
+{
+    int d = 100;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_flatl2_100d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    index.add(xb, nb);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    // std::cout << "DescriptorSet: " << std::endl;
+    for (auto& desc : desc_ids) {
+        // std::cout << desc << " ";
+        EXPECT_EQ(desc, exp++);
+    }
+
+    // std::cout << "Distances: " << std::endl;
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(2, 2)*d),
+                       float(std::pow(3, 2)*d) };
+
+    for (int i = 0; i < 4; ++i) {
+        // std::cout << distances[i] <<  " ";
+        EXPECT_EQ(distances[i], results[i]);
+    }
+    // std::cout << std::endl;
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Add, add_and_radius_search_flatl2_100d)
+{
+    int d = 100;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_and_radius_search_flatl2_100d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    index.add(xb, nb);
+
+    long* desc_ids   = new long [20];
+    float* distances = new float[20];
+    index.radius_search(xb, 2000, desc_ids, distances);
+
+    int exp = 0;
+
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(2, 2)*d),
+                       float(std::pow(3, 2)*d) };
+
+    for (int i = 0; i < 4; ++i) {
+        // std::cout << distances[i] <<  " ";
+        EXPECT_EQ(distances[i], results[i]);
+    }
+    // std::cout << std::endl;
+
+    index.store();
+
+    delete [] xb;
+}
+
+
+TEST(Descriptors_Add, add_ivfflatl2_100d)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_ivfflatl2_100d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissIVFFlat);
+
+    std::vector<long> classes(nb);
+
+    for (auto& str : classes) {
+        str = 1;
+    }
+
+    index.add(xb, nb, classes);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    // std::cout << "DescriptorSet: " << std::endl;
+    for (auto& desc : desc_ids) {
+        // std::cout << desc << " ";
+        EXPECT_EQ(desc, exp++);
+    }
+    // std::cout << std::endl;
+
+    // std::cout << "Distances: " << std::endl;
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(2, 2)*d),
+                       float(std::pow(3, 2)*d) };
+    for (int i = 0; i < 4; ++i) {
+        // std::cout << distances[i] <<  " ";
+        EXPECT_EQ(distances[i], results[i]);
+    }
+    // std::cout << std::endl;
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Add, add_recons_flatl2_100d)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_recons_flatl2_100d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    std::vector<long> classes(nb);
+
+    for (auto& cl : classes) {
+        cl = 1;
+    }
+
+    index.add(xb, nb, classes);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+    desc_ids.clear();
+
+    float *recons = new float[d * nb];
+    for (int i = 0; i < nb; ++i) {
+        desc_ids.push_back(i);
+    }
+
+    index.get_descriptors(desc_ids, recons);
+
+    for (int i = 0; i < nb*d; ++i) {
+        EXPECT_EQ(xb[i], recons[i]);
+    }
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Add, add_flatl2_100d_2add)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_flatl2_100d_2add";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    index.add(xb, nb);
+
+    generate_desc_linear_increase(d, nb, xb, .6);
+
+    index.add(xb, nb);
+
+    generate_desc_linear_increase(d, 4, xb, 0);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(.6, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(1.6, 2)*d) };
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(int(distances[i]), int(results[i]));
+    }
+
+    index.store();
+    delete [] xb;
+}
+
+// TileDB Dense Tests
+
+TEST(Descriptors_Add, add_tiledbdense_100d)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_tiledbdense_100d_tdb";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::TileDBDense);
+
+    index.add(xb, nb);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    // std::cout << "DescriptorSet: " << std::endl;
+    for (auto& desc : desc_ids) {
+        // std::cout << desc << " ";
+        EXPECT_EQ(desc, exp++);
+    }
+
+    // std::cout << "Distances: " << std::endl;
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(2, 2)*d),
+                       float(std::pow(3, 2)*d) };
+    for (int i = 0; i < 4; ++i) {
+        // std::cout << distances[i] <<  " ";
+        EXPECT_EQ(distances[i], results[i]);
+    }
+    // std::cout << std::endl;
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Add, add_tiledbdense_100d_2add)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/add_tiledbdense_100d_2add";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::TileDBDense);
+
+    index.add(xb, nb);
+
+    generate_desc_linear_increase(d, nb, xb, .6);
+
+    index.add(xb, nb);
+
+    generate_desc_linear_increase(d, 4, xb, 0);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(.6, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(1.6, 2)*d) };
+    // This is:
+    //  (0)  ^2 * 100 = 0
+    //  (0.6)^2 * 100 = 36
+    //  (1  )^2 * 100 = 100
+    //  (1.6)^2 * 100 = 256
+
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(std::round(distances[i]), std::round(results[i]));
+        // printf(" %f, %f \n", float(distances[i]), float(results[i]));
+    }
+
+    index.store();
+    delete [] xb;
+}
+
+// TileDB Sparse
+
+#define TDB_SPARSE
+#ifdef TDB_SPARSE
+
+TEST(Descriptors_Add, add_tiledbsparse_100d_2add)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+    // generate_desc_linear_increase(d, nb, xb, .1);
+
+    std::string index_filename = "dbs/add_tiledbsparse_100d_2add";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::TileDBSparse);
+
+    index.add(xb, nb);
+
+    generate_desc_linear_increase(d, nb, xb, .6);
+
+    index.add(xb, nb);
+
+    generate_desc_linear_increase(d, 4, xb, 0);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 2, 4, desc_ids, distances);
+
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(.6, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(1.6, 2)*d) };
+
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(std::round(distances[i]), std::round(results[i]));
+    }
+
+    index.store();
+    delete [] xb;
+}
+
+TEST(Descriptors_Add, add_tiledbsparse_100d)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+    // generate_desc_linear_increase(d, nb, xb, .1);
+
+    std::string index_filename = "dbs/add_tiledbsparse_100d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::TileDBSparse);
+
+    index.add(xb, nb);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    float results[] = {float(std::pow(0, 2)*d),
+                       float(std::pow(1, 2)*d),
+                       float(std::pow(2, 2)*d),
+                       float(std::pow(3, 2)*d) };
+
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(std::round(distances[i]), std::round(results[i]));
+    }
+
+    index.store();
+    delete [] xb;
+}
+
+TEST(Descriptors_Add, add_2_times_same_tdbsparse)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        auto eng = VCL::TileDBSparse;
+
+        std::string index_filename = "dbs/add_2_times_same_tdbsparse_" +
+                                     std::to_string(d) + "_" +
+                                     std::to_string(eng);
+
+        VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+        index.add(xb, nb);
+
+        generate_desc_linear_increase(d, nb, xb, 10000);
+
+        index.add(xb, nb);
+
+        generate_desc_linear_increase(d, 4, xb, 0);
+
+        std::vector<float> distances;
+        std::vector<long> desc_ids;
+        index.search(xb, 1, 4, desc_ids, distances);
+
+        float results[] = {float(std::pow(0, 2)*d),
+                           float(std::pow(1, 2)*d),
+                           float(std::pow(2, 2)*d),
+                           float(std::pow(3, 2)*d) };
+
+        for (int i = 0; i < 4; ++i) {
+            EXPECT_NEAR((distances[i]), (results[i]), .5f);
+        }
+
+        delete [] xb;
+    }
+}
+
+TEST(Descriptors_Add, add_2_times_tdbsparse)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        auto eng = VCL::TileDBSparse;
+
+        std::string index_filename = "dbs/add_2_times_tdbsparse_" +
+                                     std::to_string(d) + "_" +
+                                     std::to_string(eng);
+
+        VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+        index.add(xb, nb);
+
+        generate_desc_linear_increase(d, nb, xb, .6);
+
+        index.add(xb, nb);
+
+        generate_desc_linear_increase(d, 4, xb, 0);
+
+        std::vector<float> distances;
+        std::vector<long> desc_ids;
+        index.search(xb, 1, 4, desc_ids, distances);
+
+        float results[] = {float(std::pow(0, 2)*d),
+                           float(std::pow(.6, 2)*d),
+                           float(std::pow(1, 2)*d),
+                           float(std::pow(1.6, 2)*d) };
+
+        for (int i = 0; i < 4; ++i) {
+            EXPECT_NEAR((distances[i]), (results[i]), .5f);
+        }
+
+        delete [] xb;
+    }
+}
+
+#endif
+
+// ----------
+
+TEST(Descriptors_Add, add_and_search_10k)
+{
+    int nb = 10000;
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        for (auto eng : get_engines()) {
+            std::string index_filename = "dbs/add_and_search_10k" +
+                                         std::to_string(d) + "_" +
+                                         std::to_string(eng);
+
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            index.add(xb, nb);
+
+            std::vector<float> distances;
+            std::vector<long> desc_ids;
+            index.search(xb, 1, 4, desc_ids, distances);
+
+            int exp = 0;
+            // std::cout << "DescriptorSet: " << std::endl;
+            for (auto& desc : desc_ids) {
+                // std::cout << desc << " ";
+                EXPECT_EQ(desc, exp++);
+            }
+
+            // std::cout << "Distances: " << std::endl;
+            float results[] = {float(std::pow(0, 2)*d),
+                               float(std::pow(1, 2)*d),
+                               float(std::pow(2, 2)*d),
+                               float(std::pow(3, 2)*d) };
+            for (int i = 0; i < 4; ++i) {
+                // std::cout << distances[i] <<  " ";
+                EXPECT_EQ(distances[i], results[i]);
+            }
+            // std::cout << std::endl;
+
+            index.store();
+        }
+
+        delete [] xb;
+    }
+}
+
+// TEST(Descriptors_Add, add_and_search_10k_negative)
+// {
+//     int nb = 10000;
+//     auto dimensions_list = get_dimensions_list();
+
+//     for (auto d : dimensions_list) {
+
+//         float *xb = generate_desc_linear_increase(d, nb, -900);
+
+//         for (auto eng : get_engines()) {
+//             std::string index_filename = "dbs/add_and_search_10k_negative" +
+//                                          std::to_string(d) + "_" +
+//                                          std::to_string(eng);
+
+//             VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+//             index.add(xb, nb);
+
+//             std::vector<float> distances;
+//             std::vector<long> desc_ids;
+//             index.search(xb, 1, 4, desc_ids, distances);
+
+//             int exp = 0;
+//             // std::cout << "DescriptorSet: " << std::endl;
+//             for (auto& desc : desc_ids) {
+//                 // std::cout << desc << " ";
+//                 EXPECT_EQ(desc, exp++);
+//             }
+
+//             // std::cout << "Distances: " << std::endl;
+//             float results[] = {float(std::pow(0, 2)*d),
+//                                float(std::pow(1, 2)*d),
+//                                float(std::pow(2, 2)*d),
+//                                float(std::pow(3, 2)*d) };
+//             for (int i = 0; i < 4; ++i) {
+//                 // std::cout << distances[i] <<  " ";
+//                 EXPECT_EQ(distances[i], results[i]);
+//             }
+//             // std::cout << std::endl;
+
+//             index.store();
+//         }
+
+//         delete [] xb;
+//     }
+// }
+
+// TEST(Descriptors_Add, add_1by1_and_search_1k)
+// {
+//     int nb = 1000;
+//     auto dimensions_list = get_dimensions_list();
+
+//     for (auto d : dimensions_list) {
+
+//         float *xb = generate_desc_linear_increase(d, nb);
+
+//         for (auto eng : get_engines()) {
+
+//             // It does not make sense to run on this index
+//             if (eng == VCL::FaissIVFFlat)
+//                 continue;
+
+//             std::string index_filename = "dbs/add_1by1_and_search_1k_" +
+//                                          std::to_string(d) + "_" +
+//                                          std::to_string(eng);
+
+//             VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+//             printf("eng: %d \n",eng );
+//             for (int i = 0; i < nb; ++i) {
+//                 // printf("about to insert to eng: %d, ele: %d\n",eng, i );
+//                 index.add(xb + i*d, 1);
+//             }
+
+//             // printf("about to store the index\n");
+//             // index.store();
+
+//             printf("about to start search... \n");
+//             std::vector<float> distances;
+//             std::vector<long> desc_ids;
+//             index.search(xb, 1, 4, desc_ids, distances);
+
+//             printf("done search\n");
+
+//             int exp = 0;
+//             // std::cout << "DescriptorSet: " << std::endl;
+//             for (auto& desc : desc_ids) {
+//                 // std::cout << desc << " ";
+//                 EXPECT_EQ(desc, exp++);
+//             }
+
+//             // std::cout << "Distances: " << std::endl;
+//             float results[] = {float(std::pow(0, 2)*d),
+//                                float(std::pow(1, 2)*d),
+//                                float(std::pow(2, 2)*d),
+//                                float(std::pow(3, 2)*d) };
+//             for (int i = 0; i < 4; ++i) {
+//                 // std::cout << distances[i] <<  " ";
+//                 EXPECT_EQ(distances[i], results[i]);
+//             }
+//             // std::cout << std::endl;
+
+//             index.store();
+//             printf("donde store\n");
+//         }
+
+//         delete [] xb;
+//     }
+// }
+
+TEST(Descriptors_Add, add_and_search_2_neigh_10k)
+{
+    int nb = 10000;
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        for (auto eng : get_engines()) {
+            std::string index_filename = "dbs/add_and_search_2_neigh_10k" +
+                                         std::to_string(d) + "_" +
+                                         std::to_string(eng);
+
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            index.add(xb, nb);
+
+            std::vector<float> distances;
+            std::vector<long> desc_ids;
+            index.search(xb, 2, 4, desc_ids, distances);
+
+            // Does not matter much, but good to test
+            // int exp[] = {0, 1, 2, 3, 1, 2, 0, 3};
+            // int idx = 0;
+            // // std::cout << "DescriptorSet: " << std::endl;
+            // for (auto& desc : desc_ids) {
+            //     // std::cout << desc << " ";
+            //     EXPECT_EQ(desc, exp[idx++]);
+            // }
+
+            // std::cout << "Distances: " << std::endl;
+            float results[] = {float(std::pow(0, 2)*d),
+                               float(std::pow(1, 2)*d),
+                               float(std::pow(2, 2)*d),
+                               float(std::pow(3, 2)*d) };
+            for (int i = 0; i < 4; ++i) {
+                // std::cout << distances[i] <<  " ";
+                EXPECT_EQ(distances[i], results[i]);
+            }
+
+            float results_2[] = {float(std::pow(0, 2)*d),
+                               float(std::pow(1, 2)*d),
+                               float(std::pow(1, 2)*d),
+                               float(std::pow(2, 2)*d) };
+
+            for (int i = 4; i < 8; ++i) {
+                // std::cout << distances[i] <<  " ";
+                EXPECT_EQ(distances[i], results_2[i-4]);
+            }
+            // std::cout << std::endl;
+
+            index.store();
+        }
+
+        delete [] xb;
+    }
+}
+
+TEST(Descriptors_Add, add_2_times)
+{
+    // int d = 100;
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        for (auto eng : get_engines()) {
+
+            // this eng is segfaulting, possible tdb bug
+            if (eng == VCL::TileDBSparse)
+                continue;
+
+            std::string index_filename = "dbs/add_2_times_" +
+                                         std::to_string(d) + "_" +
+                                         std::to_string(eng);
+
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            index.add(xb, nb);
+
+            generate_desc_linear_increase(d, nb, xb, .6);
+
+            index.add(xb, nb);
+
+            generate_desc_linear_increase(d, 4, xb, 0);
+
+            std::vector<float> distances;
+            std::vector<long> desc_ids;
+            index.search(xb, 1, 4, desc_ids, distances);
+
+            float results[] = {float(std::pow(0, 2)*d),
+                               float(std::pow(.6, 2)*d),
+                               float(std::pow(1, 2)*d),
+                               float(std::pow(1.6, 2)*d) };
+
+            for (int i = 0; i < 4; ++i) {
+                EXPECT_NEAR((distances[i]), (results[i]), .5f);
+            }
+        }
+
+        delete [] xb;
+    }
+}
+
+TEST(Descriptors_Add, add_and_get_descriptors)
+{
+    int nb = 10000;
+
+    int recons_n = 10;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        std::vector<long> recons_ids;
+        for (int i = 0; i < recons_n; ++i) {
+            recons_ids.push_back(i);
+        }
+
+        for (auto eng : get_engines()) {
+
+            std::string index_filename = "dbs/add_and_get_descriptors_10k" +
+                                         std::to_string(d) + "_" +
+                                         std::to_string(eng);
+
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            index.add(xb, nb);
+
+            float *recons = new float[d * recons_n];
+            index.get_descriptors(recons_ids, recons);
+
+            for (int i = 0; i < recons_n*d; ++i) {
+                EXPECT_NEAR(xb[i], recons[i], .01f);
+            }
+            // printf("%d\n", eng);
+
+            delete[] recons;
+
+            index.store();
+        }
+
+        delete [] xb;
+    }
+}

--- a/test/unit_tests/DescriptorSetClassify_test.cc
+++ b/test/unit_tests/DescriptorSetClassify_test.cc
@@ -1,0 +1,374 @@
+/**
+ * @file   DescriptorSetClassify_test.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+
+#include "VCL.h"
+#include "gtest/gtest.h"
+#include "helpers.h"
+
+TEST(Descriptors_Classify, classify_flatl2_4d)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/classify_flatl2_4d.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.add(xb, nb, classes);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+
+    exp = 0;
+    int i = 0;
+    for (auto& id : ret_ids) {
+        EXPECT_EQ(id, exp);
+        if (++i % offset == 0 )
+            ++exp;
+    }
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Classify, classify_10k)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    for (auto eng : get_engines()) {
+        std::string index_filename = "dbs/classify_10k" +
+                                     std::to_string(d) + "_" +
+                                     std::to_string(eng);
+
+        VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+        int offset = 10;
+        std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+        index.add(xb, nb, classes);
+
+        std::vector<float> distances;
+        std::vector<long> desc_ids;
+        index.search(xb, 1, 4, desc_ids, distances);
+
+        int exp = 0;
+        for (auto& desc : desc_ids) {
+            EXPECT_EQ(desc, exp++);
+        }
+
+        std::vector<long> ret_ids = index.classify(xb, 60);
+
+        exp = 0;
+        int i = 0;
+        for (auto& id : ret_ids) {
+            // printf("%ld - %ld \n", id, exp);
+            EXPECT_EQ(id, exp);
+            if (++i % offset == 0 )
+                ++exp;
+        }
+
+        index.store();
+    }
+
+    delete [] xb;
+    }
+}
+
+
+// String labels tests
+
+TEST(Descriptors_Classify, classify_ivfflatl2_4d_labels)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    auto class_map = animals_map();
+
+    std::string index_filename = "dbs/classify_ivfflatl2_4d_labels.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissIVFFlat);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.set_labels_map(class_map);
+
+    index.add(xb, nb, classes);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+    std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+    for (int i = 0; i < offset; ++i) {
+        EXPECT_EQ(ret[i], "parrot");
+        EXPECT_EQ(ret[i+offset], "dog");
+        EXPECT_EQ(ret[i+2*offset], "cat");
+        EXPECT_EQ(ret[i+3*offset], "messi");
+        EXPECT_EQ(ret[i+4*offset], "bird");
+        EXPECT_EQ(ret[i+5*offset], "condor");
+    }
+
+    index.search(xb, 1, offset, desc_ids, distances);
+    ret = index.get_str_labels(desc_ids);
+
+    for (auto& label : ret){
+        EXPECT_EQ(label, "parrot");
+    }
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Classify, classify_labels_10k)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+    auto class_map = animals_map();
+
+    for (auto d : dimensions_list) {
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        for (auto eng : get_engines()) {
+            std::string index_filename = "dbs/classify_labels_10k_" +
+                                             std::to_string(d) + "_" +
+                                             std::to_string(eng);
+
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            int offset = 10;
+            std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+            index.set_labels_map(class_map);
+
+            index.add(xb, nb, classes);
+
+            std::vector<float> distances;
+            std::vector<long> desc_ids;
+            index.search(xb, 1, 4, desc_ids, distances);
+
+            int exp = 0;
+            for (auto& desc : desc_ids) {
+                EXPECT_EQ(desc, exp++);
+            }
+
+            std::vector<long> ret_ids = index.classify(xb, 60);
+            std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+            for (int i = 0; i < offset; ++i) {
+                EXPECT_EQ(ret[i], "parrot");
+                EXPECT_EQ(ret[i+offset], "dog");
+                EXPECT_EQ(ret[i+2*offset], "cat");
+                EXPECT_EQ(ret[i+3*offset], "messi");
+                EXPECT_EQ(ret[i+4*offset], "bird");
+                EXPECT_EQ(ret[i+5*offset], "condor");
+            }
+
+            index.search(xb, 1, offset, desc_ids, distances);
+            ret = index.get_str_labels(desc_ids);
+
+            for (auto& label : ret){
+                EXPECT_EQ(label, "parrot");
+            }
+
+            index.store();
+        }
+
+        delete [] xb;
+    }
+}
+
+TEST(Descriptors_Classify, classify_flatl2_4d_str_label)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/classify_flatl2_4d_str_label.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    auto class_map = animals_map();
+    index.set_labels_map(class_map);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.add(xb, nb, classes);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+
+    std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+    for (int i = 0; i < offset; ++i) {
+        EXPECT_EQ(ret[i], "parrot");
+        EXPECT_EQ(ret[i+offset], "dog");
+        EXPECT_EQ(ret[i+2*offset], "cat");
+        EXPECT_EQ(ret[i+3*offset], "messi");
+        EXPECT_EQ(ret[i+4*offset], "bird");
+        EXPECT_EQ(ret[i+5*offset], "condor");
+    }
+
+    desc_ids.clear();
+    distances.clear();
+
+    index.search(xb, 1, offset, desc_ids, distances);
+    ret = index.get_str_labels(desc_ids);
+
+    for (auto& label : ret) {
+        EXPECT_EQ(label, "parrot");
+    }
+
+    index.store();
+
+    delete [] xb;
+}
+
+// TILEDBDense tests
+
+TEST(Descriptors_Classify, classify_tdbdense_4d)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    auto class_map = animals_map();
+
+    std::string index_filename = "dbs/classify_tdbdense_4d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::TileDBDense);
+
+    index.set_labels_map(class_map);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.add(xb, nb, classes);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+
+    std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+    for (int i = 0; i < offset; ++i) {
+        EXPECT_EQ(ret[i], "parrot");
+        EXPECT_EQ(ret[i+offset], "dog");
+        EXPECT_EQ(ret[i+2*offset], "cat");
+        EXPECT_EQ(ret[i+3*offset], "messi");
+        EXPECT_EQ(ret[i+4*offset], "bird");
+        EXPECT_EQ(ret[i+5*offset], "condor");
+    }
+
+    desc_ids.clear();
+    distances.clear();
+
+    index.search(xb, 1, offset, desc_ids, distances);
+    ret = index.get_str_labels(desc_ids);
+
+    for (auto& label : ret) {
+        // std::cout << label << std::endl;
+        EXPECT_EQ(label, "parrot");
+    }
+
+    index.store();
+
+    delete [] xb;
+}

--- a/test/unit_tests/DescriptorSetReadFS_test.cc
+++ b/test/unit_tests/DescriptorSetReadFS_test.cc
@@ -1,0 +1,129 @@
+/**
+ * @file   DescriptorSetReadFS_test.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <cmath>
+#include <list>
+
+#include "VCL.h"
+#include "helpers.h"
+#include "gtest/gtest.h"
+
+TEST(Descriptors_ReadFS, read_and_search_10k)
+{
+    int nb = 10000;
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        for (auto eng : get_engines()) {
+
+            std::string index_filename = "dbs/read_and_search_10k" +
+                                         std::to_string(d) + "_" +
+                                         std::to_string(eng);
+            {
+                VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+                index.add(xb, nb);
+                index.store();
+            }
+
+            VCL::DescriptorSet index_fs(index_filename);
+
+            std::vector<float> distances;
+            std::vector<long> desc_ids;
+            index_fs.search(xb, 1, 4, desc_ids, distances);
+
+            int exp = 0;
+            for (auto& desc : desc_ids) {
+                EXPECT_EQ(desc, exp++);
+            }
+
+            float results[] = {float(std::pow(0, 2)*d),
+                               float(std::pow(1, 2)*d),
+                               float(std::pow(2, 2)*d),
+                               float(std::pow(3, 2)*d) };
+            for (int i = 0; i < 4; ++i) {
+                EXPECT_EQ(distances[i], results[i]);
+            }
+        }
+
+        delete [] xb;
+    }
+}
+
+TEST(Descriptors_ReadFS, read_and_classify_10k)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    for (auto eng : get_engines()) {
+        std::string index_filename = "dbs/read_and_classify_10k" +
+                                     std::to_string(d) + "_" +
+                                     std::to_string(eng);
+        int offset = 10;
+
+        {
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+            index.add(xb, nb, classes);
+            index.store();
+        }
+
+        VCL::DescriptorSet index_fs(index_filename);
+
+        std::vector<long> ret_ids = index_fs.classify(xb, 60);
+
+        int exp = 0;
+        int i = 0;
+        for (auto& id : ret_ids) {
+            // printf("%ld - %ld \n", id, exp);
+            EXPECT_EQ(id, exp);
+            if (++i % offset == 0 )
+                ++exp;
+        }
+    }
+
+    delete [] xb;
+    }
+}

--- a/test/unit_tests/DescriptorSetStore_test.cc
+++ b/test/unit_tests/DescriptorSetStore_test.cc
@@ -1,0 +1,146 @@
+/**
+ * @file   DescriptorSetStore_test.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <cmath>
+
+#include "VCL.h"
+#include "helpers.h"
+#include "gtest/gtest.h"
+
+TEST(Descriptors_Store, add_ivfflatl2_100d_2add_file)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/store_ivfflatl2_100d_2add.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissIVFFlat);
+
+    index.add(xb, nb);
+    index.store();
+
+    generate_desc_linear_increase(d, nb, xb, .6);
+
+    VCL::DescriptorSet index_f(index_filename);
+    index_f.add(xb, nb);
+
+    generate_desc_linear_increase(d, 4, xb, 0);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index_f.search(xb, 1, 4, desc_ids, distances);
+
+    float results[] = {0,36,100,256};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(int(distances[i]), int(results[i]));
+    }
+
+    index_f.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Store, add_tiledbdense_100d_file)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/store_tiledbdense_100d_tdb";
+    VCL::DescriptorSet index_f(index_filename, unsigned(d), VCL::TileDBDense);
+
+    index_f.add(xb, nb);
+    index_f.store();
+
+    VCL::DescriptorSet index(index_filename);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,100,400,900};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Store, add_tiledbdense_100d_2add_file)
+{
+    int d = 100;
+    int nb = 10000;
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/store_tiledbdense_100d_2add";
+    VCL::DescriptorSet index_f(index_filename, unsigned(d), VCL::TileDBDense);
+
+    index_f.add(xb, nb);
+
+    generate_desc_linear_increase(d, nb, xb, .6);
+
+    index_f.add(xb, nb);
+    index_f.store();
+
+    generate_desc_linear_increase(d, 4, xb, 0);
+
+    VCL::DescriptorSet index(index_filename);
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    float results[] = {0,36,100,256};
+    // This is:
+    //  (0)  ^2 * 100 = 0
+    //  (0.6)^2 * 100 = 36
+    //  (1  )^2 * 100 = 100
+    //  (1.6)^2 * 100 = 256
+
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(std::round(distances[i]), std::round(results[i]));
+    }
+
+    index.store();
+    delete [] xb;
+}

--- a/test/unit_tests/DescriptorSetTrain_test.cc
+++ b/test/unit_tests/DescriptorSetTrain_test.cc
@@ -1,0 +1,384 @@
+/**
+ * @file   DescriptorSetTrain_test.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files
+ * (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+
+#include "VCL.h"
+#include "gtest/gtest.h"
+#include "helpers.h"
+
+TEST(Descriptors_Train, train_flatl2_4d)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/train_flatl2_4d.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.add(xb, nb, classes);
+
+    index.train();
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+
+    exp = 0;
+    int i = 0;
+    for (auto& id : ret_ids) {
+        EXPECT_EQ(id, exp);
+        if (++i % offset == 0 )
+            ++exp;
+    }
+
+    index.store();
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Train, train_10k)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+
+    for (auto d : dimensions_list) {
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    for (auto eng : get_engines()) {
+        std::string index_filename = "dbs/train_10k" +
+                                     std::to_string(d) + "_" +
+                                     std::to_string(eng);
+
+        VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+        int offset = 10;
+        std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+        index.add(xb, nb, classes);
+
+        index.train();
+
+        std::vector<float> distances;
+        std::vector<long> desc_ids;
+        index.search(xb, 1, 4, desc_ids, distances);
+
+        int exp = 0;
+        for (auto& desc : desc_ids) {
+            EXPECT_EQ(desc, exp++);
+        }
+
+        std::vector<long> ret_ids = index.classify(xb, 60);
+
+        exp = 0;
+        int i = 0;
+        for (auto& id : ret_ids) {
+            // printf("%ld - %ld \n", id, exp);
+            EXPECT_EQ(id, exp);
+            if (++i % offset == 0 )
+                ++exp;
+        }
+
+        index.store();
+    }
+
+    delete [] xb;
+    }
+}
+
+
+// String labels tests
+
+TEST(Descriptors_Train, train_ivfflatl2_4d_labels)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    auto class_map = animals_map();
+
+    std::string index_filename = "dbs/train_ivfflatl2_4d_labels.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissIVFFlat);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.set_labels_map(class_map);
+
+    index.add(xb, nb, classes);
+
+    index.train();
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+    std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+    for (int i = 0; i < offset; ++i) {
+        EXPECT_EQ(ret[i], "parrot");
+        EXPECT_EQ(ret[i+offset], "dog");
+        EXPECT_EQ(ret[i+2*offset], "cat");
+        EXPECT_EQ(ret[i+3*offset], "messi");
+        EXPECT_EQ(ret[i+4*offset], "bird");
+        EXPECT_EQ(ret[i+5*offset], "condor");
+    }
+
+    index.search(xb, 1, offset, desc_ids, distances);
+    ret = index.get_str_labels(desc_ids);
+
+    for (auto& label : ret){
+        EXPECT_EQ(label, "parrot");
+    }
+
+    delete [] xb;
+}
+
+TEST(Descriptors_Train, train_labels_10k)
+{
+    int nb = 10000;
+
+    auto dimensions_list = get_dimensions_list();
+    auto class_map = animals_map();
+
+    for (auto d : dimensions_list) {
+        float *xb = generate_desc_linear_increase(d, nb);
+
+        for (auto eng : get_engines()) {
+            std::string index_filename = "dbs/train_labels_10k_" +
+                                             std::to_string(d) + "_" +
+                                             std::to_string(eng);
+
+            VCL::DescriptorSet index(index_filename, unsigned(d), eng);
+
+            int offset = 10;
+            std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+            index.set_labels_map(class_map);
+
+            index.add(xb, nb, classes);
+
+            index.train();
+
+            std::vector<float> distances;
+            std::vector<long> desc_ids;
+            index.search(xb, 1, 4, desc_ids, distances);
+
+            int exp = 0;
+            for (auto& desc : desc_ids) {
+                EXPECT_EQ(desc, exp++);
+            }
+
+            std::vector<long> ret_ids = index.classify(xb, 60);
+            std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+            for (int i = 0; i < offset; ++i) {
+                EXPECT_EQ(ret[i], "parrot");
+                EXPECT_EQ(ret[i+offset], "dog");
+                EXPECT_EQ(ret[i+2*offset], "cat");
+                EXPECT_EQ(ret[i+3*offset], "messi");
+                EXPECT_EQ(ret[i+4*offset], "bird");
+                EXPECT_EQ(ret[i+5*offset], "condor");
+            }
+
+            index.search(xb, 1, offset, desc_ids, distances);
+            ret = index.get_str_labels(desc_ids);
+
+            for (auto& label : ret){
+                EXPECT_EQ(label, "parrot");
+            }
+
+            index.store();
+        }
+
+        delete [] xb;
+    }
+}
+
+TEST(Descriptors_Train, train_flatl2_4d_str_label)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    std::string index_filename = "dbs/train_flatl2_4d_str_label.faiss";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::FaissFlat);
+
+    auto class_map = animals_map();
+    index.set_labels_map(class_map);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.add(xb, nb, classes);
+    index.train();
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+
+    std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+    for (int i = 0; i < offset; ++i) {
+        EXPECT_EQ(ret[i], "parrot");
+        EXPECT_EQ(ret[i+offset], "dog");
+        EXPECT_EQ(ret[i+2*offset], "cat");
+        EXPECT_EQ(ret[i+3*offset], "messi");
+        EXPECT_EQ(ret[i+4*offset], "bird");
+        EXPECT_EQ(ret[i+5*offset], "condor");
+    }
+
+    desc_ids.clear();
+    distances.clear();
+
+    index.search(xb, 1, offset, desc_ids, distances);
+    ret = index.get_str_labels(desc_ids);
+
+    for (auto& label : ret) {
+        EXPECT_EQ(label, "parrot");
+    }
+
+    index.store();
+
+    delete [] xb;
+}
+
+// TILEDBDense tests
+
+TEST(Descriptors_Train, train_tdbdense_4d)
+{
+    int d = 4;
+    int nb = 10000;
+
+    float *xb = generate_desc_linear_increase(d, nb);
+
+    auto class_map = animals_map();
+
+    std::string index_filename = "dbs/train_tdbdense_4d";
+    VCL::DescriptorSet index(index_filename, unsigned(d), VCL::TileDBDense);
+
+    index.set_labels_map(class_map);
+
+    int offset = 10;
+    std::vector<long> classes = classes_increasing_offset(nb, offset);
+
+    index.add(xb, nb, classes);
+    index.train();
+
+    std::vector<float> distances;
+    std::vector<long> desc_ids;
+    index.search(xb, 1, 4, desc_ids, distances);
+
+    int exp = 0;
+    for (auto& desc : desc_ids) {
+        EXPECT_EQ(desc, exp++);
+    }
+
+    int results[] = {0,4,16,36};
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(distances[i], results[i]);
+    }
+
+    std::vector<long> ret_ids = index.classify(xb, 60);
+
+    std::vector<std::string> ret = index.label_id_to_string(ret_ids);
+
+    for (int i = 0; i < offset; ++i) {
+        EXPECT_EQ(ret[i], "parrot");
+        EXPECT_EQ(ret[i+offset], "dog");
+        EXPECT_EQ(ret[i+2*offset], "cat");
+        EXPECT_EQ(ret[i+3*offset], "messi");
+        EXPECT_EQ(ret[i+4*offset], "bird");
+        EXPECT_EQ(ret[i+5*offset], "condor");
+    }
+
+    desc_ids.clear();
+    distances.clear();
+
+    index.search(xb, 1, offset, desc_ids, distances);
+    ret = index.get_str_labels(desc_ids);
+
+    for (auto& label : ret) {
+        // std::cout << label << std::endl;
+        EXPECT_EQ(label, "parrot");
+    }
+
+    index.store();
+
+    delete [] xb;
+}

--- a/test/unit_tests/helpers.cc
+++ b/test/unit_tests/helpers.cc
@@ -1,0 +1,108 @@
+/**
+ * @file   helpers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <cmath>
+
+#include "helpers.h"
+
+// This function return nb descriptors of dimension d as follows:
+// init       init      ...   init      (d times)
+// init+1     init+1    ...   init+1    (d times)
+// ...
+// init+nb-1  init+nb-1 ...   init+nb-1 (d times)
+
+void generate_desc_linear_increase(int d, int nb, float* xb, float init)
+{
+    float val = init;
+    for (int i = 1; i <= nb*d; ++i) {
+        xb[i-1] = val;
+        if ( i%d == 0) val++;
+    }
+}
+
+float* generate_desc_linear_increase(int d, int nb, float init)
+{
+    float *xb = new float[d * nb];
+    generate_desc_linear_increase(d, nb, xb, init);
+    return xb;
+}
+
+std::map<long, std::string> animals_map()
+{
+    std::map<long, std::string> class_map;
+    class_map[0] = "parrot";
+    class_map[1] = "dog";
+    class_map[2] = "cat";
+    class_map[3] = "messi";
+    class_map[4] = "bird";
+    class_map[5] = "condor";
+    class_map[6] = "panda";
+
+    return class_map;
+}
+
+std::vector<long> classes_increasing_offset(unsigned nb, unsigned offset)
+{
+    std::vector<long> classes(nb, 0);
+
+    for (int i = 0; i < nb/offset; ++i) {
+        for (int j = 0; j < offset; ++j) {
+            classes[i*offset + j] = i;
+        }
+    }
+
+    return classes;
+}
+
+std::vector<VCL::DescriptorSetEngine> get_engines()
+{
+    std::vector<VCL::DescriptorSetEngine> engs;
+    engs.push_back(VCL::FaissFlat);
+    engs.push_back(VCL::FaissIVFFlat);
+    engs.push_back(VCL::TileDBDense);
+    engs.push_back(VCL::TileDBSparse);
+
+    return engs;
+}
+
+std::list<int> get_dimensions_list()
+{
+    // std::list<int> dims = {64, 97, 128, 256, 300, 453, 1000, 1024, 2045};
+    // std::list<int> dims = {128, 300, 453, 1024};
+    // std::list<int> dims = {128, 300, 453};
+    // std::list<int> dims = {128, 255};
+    std::list<int> dims = {128};
+
+    return dims;
+}

--- a/test/unit_tests/helpers.h
+++ b/test/unit_tests/helpers.h
@@ -1,5 +1,5 @@
 /**
- * @file   VCL.h
+ * @file   helpers.h
  *
  * @section LICENSE
  *
@@ -8,7 +8,8 @@
  * @copyright Copyright (c) 2017 Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
+ * of this software and associated documentation files
+ * (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
@@ -21,16 +22,31 @@
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
- * @section DESCRIPTION
  *
  */
 
 #pragma once
 
-#include "Exception.h"
-#include "Image.h"
-#include "DescriptorSet.h"
+#include <cstdio>
+#include <cstdlib>
+#include <list>
+
+#include "VCL.h"
+
+void generate_desc_linear_increase(int d, int nb, float* xb, float init = 0);
+
+float* generate_desc_linear_increase(int d, int nb, float init = 0);
+
+void check_arrays_float(float* a, float* b, int d);
+
+std::map<long, std::string> animals_map();
+
+std::vector<long> classes_increasing_offset(unsigned nb, unsigned offset);
+
+std::vector<VCL::DescriptorSetEngine> get_engines();
+
+std::list<int> get_dimensions_list();

--- a/test/unit_tests/main.cc
+++ b/test/unit_tests/main.cc
@@ -27,12 +27,16 @@
  *
  */
 
-
 #include "gtest/gtest.h"
-#include "Image.h"
 
-int main(int argc, char** argv) 
+int main(int argc, char **argv)
 {
- ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // To make GoogleTest silent:
+    // if (true) {
+    //     auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
+    //     delete listeners.Release(listeners.default_result_printer());
+    // }
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Don't look at Scons files for now, will come later with an update on it together with the installation instructions.

A couple of things that are known missing, that will be added upon my return:

* Commits with be squashed, we will have only 2. One for the core code, and another for testing code. 

* Add and Fix some of the comments for doxygen, will make a last round of updates once the interface is unchanged.

* Add radius search on TileDB, will do that soon.

* Update new dependencies on the installation instructions and handle paths better in Scons. Cmake for faiss is going away, as that wile will be covered in the instructions.

* Will check for memory leaks (there are a lot of allocations), and implemente destructors. 


About testing, here is a list of all the testing happening. 
If the name of the tests does not have any of [flat, ivfflat, tiledbdense, tiledbsparse], it means that it tests all of them. 

This is to give you an idea of what is being tested (I think all of the interfaces), so you don’t have to walk through the testing code. 


[==========] Running 30 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 30 tests from DESCRIPTORS
[ RUN      ] DESCRIPTORS.add_flatl2_100d
[       OK ] DESCRIPTORS.add_flatl2_100d (135 ms)
[ RUN      ] DESCRIPTORS.add_and_radius_search_flatl2_100d
[       OK ] DESCRIPTORS.add_and_radius_search_flatl2_100d (47 ms)
[ RUN      ] DESCRIPTORS.add_ivfflatl2_100d
[       OK ] DESCRIPTORS.add_ivfflatl2_100d (609 ms)
[ RUN      ] DESCRIPTORS.add_recons_flatl2_100d
[       OK ] DESCRIPTORS.add_recons_flatl2_100d (36 ms)
[ RUN      ] DESCRIPTORS.add_flatl2_100d_2add
[       OK ] DESCRIPTORS.add_flatl2_100d_2add (34 ms)
[ RUN      ] DESCRIPTORS.add_tiledbdense_100d
[       OK ] DESCRIPTORS.add_tiledbdense_100d (630 ms)
[ RUN      ] DESCRIPTORS.add_tiledbdense_100d_2add
[       OK ] DESCRIPTORS.add_tiledbdense_100d_2add (920 ms)
[ RUN      ] DESCRIPTORS.add_tiledbsparse_100d_2add
[       OK ] DESCRIPTORS.add_tiledbsparse_100d_2add (200 ms)
[ RUN      ] DESCRIPTORS.add_tiledbsparse_100d
[       OK ] DESCRIPTORS.add_tiledbsparse_100d (149 ms)
[ RUN      ] DESCRIPTORS.add_2_times_same_tdbsparse
[       OK ] DESCRIPTORS.add_2_times_same_tdbsparse (370 ms)
[ RUN      ] DESCRIPTORS.add_2_times_tdbsparse
[       OK ] DESCRIPTORS.add_2_times_tdbsparse (309 ms)
[ RUN      ] DESCRIPTORS.add_and_search_10k
[       OK ] DESCRIPTORS.add_and_search_10k (1435 ms)
[ RUN      ] DESCRIPTORS.add_1by1_and_search_1k
[       OK ] DESCRIPTORS.add_1by1_and_search_1k (20918 ms)
[ RUN      ] DESCRIPTORS.add_and_search_2_neigh_10k
[       OK ] DESCRIPTORS.add_and_search_2_neigh_10k (1543 ms)
[ RUN      ] DESCRIPTORS.add_2_times
[       OK ] DESCRIPTORS.add_2_times (1887 ms)
[ RUN      ] DESCRIPTORS.add_and_get_descriptors
[       OK ] DESCRIPTORS.add_and_get_descriptors (1395 ms)
[ RUN      ] DESCRIPTORS.classify_flatl2_4d
[       OK ] DESCRIPTORS.classify_flatl2_4d (150 ms)
[ RUN      ] DESCRIPTORS.classify_10k
[       OK ] DESCRIPTORS.classify_10k (2483 ms)
[ RUN      ] DESCRIPTORS.classify_ivfflatl2_4d_labels
[       OK ] DESCRIPTORS.classify_ivfflatl2_4d_labels (369 ms)
[ RUN      ] DESCRIPTORS.classify_labels_10k
[       OK ] DESCRIPTORS.classify_labels_10k (2442 ms)
[ RUN      ] DESCRIPTORS.classify_flatl2_4d_str_label
[       OK ] DESCRIPTORS.classify_flatl2_4d_str_label (157 ms)
[ RUN      ] DESCRIPTORS.classify_tdbdense_4d
[       OK ] DESCRIPTORS.classify_tdbdense_4d (401 ms)
[ RUN      ] DESCRIPTORS.train_flatl2_4d
[       OK ] DESCRIPTORS.train_flatl2_4d (200 ms)
[ RUN      ] DESCRIPTORS.train_10k
[       OK ] DESCRIPTORS.train_10k (2693 ms)
[ RUN      ] DESCRIPTORS.train_ivfflatl2_4d_labels
[       OK ] DESCRIPTORS.train_ivfflatl2_4d_labels (6 ms)
[ RUN      ] DESCRIPTORS.train_labels_10k
[       OK ] DESCRIPTORS.train_labels_10k (2410 ms)
[ RUN      ] DESCRIPTORS.train_flatl2_4d_str_label
[       OK ] DESCRIPTORS.train_flatl2_4d_str_label (172 ms)
[ RUN      ] DESCRIPTORS.train_tdbdense_4d
[       OK ] DESCRIPTORS.train_tdbdense_4d (419 ms)
[ RUN      ] DESCRIPTORS.read_and_search_10k
[       OK ] DESCRIPTORS.read_and_search_10k (2656 ms)
[ RUN      ] DESCRIPTORS.read_and_classify_10k
[       OK ] DESCRIPTORS.read_and_classify_10k (3450 ms)
[----------] 30 tests from DESCRIPTORS (48627 ms total)

[----------] Global test environment tear-down
[==========] 30 tests from 1 test case ran. (48628 ms total)
[  PASSED  ] 30 tests.